### PR TITLE
Align multiple events publishing

### DIFF
--- a/docs/features/publishing-events.md
+++ b/docs/features/publishing-events.md
@@ -29,6 +29,9 @@ var @event = new NewCarRegistered(eventId, eventSubject, licensePlate);
 await eventGridPublisher.Publish(@event);
 ```
 
-Alternatively you can publish a list of events by using `await eventGridPublisher.PublishMany(events);`.
+Alternatively you can publish a list of events by using 
+```csharp
+await eventGridPublisher.PublishMany(events);
+```
 
 [&larr; back](/arcus.eventgrid)


### PR DESCRIPTION
The last code sample doesn't look nice, this makes it use a code block as the other code snippets on the page do.

![image](https://user-images.githubusercontent.com/759160/48469365-f6951c00-e7ee-11e8-99de-7abd1ad6101c.png)
