### PR TITLE
DOC: add documentation for resilient publishing of event grid events

### DIFF
--- a/docs/features/publishing-events.md
+++ b/docs/features/publishing-events.md
@@ -4,14 +4,17 @@ layout: default
 ---
 
 ## Publishing Events
+
 We provide support for publishing custom events to a custom Azure Event Grid Topics.
 
 Import the following namespace into your project:
+
 ```csharp
 using Arcus.EventGrid.Publishing;
 ```
 
 Next, create an `EventGridPublisher` instance via the `EventGridPublisherBuilder` which requires the endpoint & authentication key of your custom topic endpoint.
+
 ```csharp
 var eventGridPublisher = EventGridPublisherBuilder
                                 .ForTopic(topicEndpoint)
@@ -20,6 +23,7 @@ var eventGridPublisher = EventGridPublisherBuilder
 ```
 
 Create your event that you want to publish
+
 ```csharp
 string licensePlate = "1-TOM-337";
 string eventSubject = $"/cars/{licensePlate}";
@@ -29,9 +33,42 @@ var @event = new NewCarRegistered(eventId, eventSubject, licensePlate);
 await eventGridPublisher.Publish(@event);
 ```
 
-Alternatively you can publish a list of events by using 
+Alternatively you can publish a list of events by using
+
 ```csharp
 await eventGridPublisher.PublishMany(events);
+```
+
+### Resilient Publishing
+
+The `EventGridPublisherBuilder` also provides several ways to publish events in a resilient manner. Resilient meaning we support three ways to add resilience to your event publishing:
+
+1. **Exponential retry**: makes the publishing resilient by retrying a specified number of times with exponential backoff.
+
+```csharp
+EventGridPublisherBuilder.ForTopic(topicEndpoint)
+                         .UsingAuthenticationKey(endpointKey)
+                         .WithExponentialRetry(retryCount)
+                         .Build();
+```
+
+2. **Circuit broker**: makes the publishing resilient by breaking the circuit if the maximum specified number of exceptions are handled by the policy. The circuit will stay broken for a specified duration. Any attempt to execute the function while the circuit is broken will result in a `BrokenCircuitException`.
+
+```csharp
+EventGridPublisherBuilder.ForTopic(topicEndpoint)
+                         .UsingAuthenticationKey(endpointKey)
+                         .WithCircuitBreaker(exceptionsBeforeBreaking, durationOfBreak)
+                         .Build();
+```
+
+3. Combination of the two: **Circuit broker with/after exponential retry**.
+
+```csharp
+EventGridPublisherBuilder.ForTopic(topicEndpoint)
+                         .UsingAuthenticationKey(endpointKey)
+                         .WithExponentialRetry(retryCount)
+                         .WithCircuitBreaker(exceptionsBeforeBreaking, durationOfBreak)
+                         .Build();
 ```
 
 [&larr; back](/arcus.eventgrid)


### PR DESCRIPTION
Adds the three possible ways of adding resilience to the event grid
publishing mechanism to the SC docs.

 #22