### PR TITLE
FEAT: add GetReceivedEvent overload with timeout for EventConsumerHost

### DIFF
--- a/src/Arcus.EventGrid.Tests.Unit/Arcus.EventGrid.Tests.Unit.csproj
+++ b/src/Arcus.EventGrid.Tests.Unit/Arcus.EventGrid.Tests.Unit.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\Arcus.EventGrid.Publishing\Arcus.EventGrid.Publishing.csproj" />
     <ProjectReference Include="..\Arcus.EventGrid.Security\Arcus.EventGrid.Security.csproj" />
     <ProjectReference Include="..\Arcus.EventGrid.Storage\Arcus.EventGrid.Storage.csproj" />
+    <ProjectReference Include="..\Arcus.EventGrid.Testing\Arcus.EventGrid.Testing.csproj" />
     <ProjectReference Include="..\Arcus.EventGrid.Tests.Core\Arcus.EventGrid.Tests.Core.csproj" />
     <ProjectReference Include="..\Arcus.EventGrid.Tests.InMemoryApi\Arcus.EventGrid.Tests.InMemoryApi.csproj" />
     <ProjectReference Include="..\Arcus.EventGrid\Arcus.EventGrid.csproj" />

--- a/src/Arcus.EventGrid.Tests.Unit/Testing/EventConsumerHostTests.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Testing/EventConsumerHostTests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Arcus.EventGrid.Testing.Infrastructure.Hosts;
+using Arcus.EventGrid.Testing.Logging;
+using Xunit;
+
+namespace Arcus.EventGrid.Tests.Unit.Testing
+{
+    public class EventConsumerHostTests
+    {
+        [Theory]
+        [InlineData("00:00:00")]
+        [InlineData("-00:01:25")]
+        [InlineData("-04:21:48")]
+        public void GetReceivedEvent_WithNegativeOrZeroTimeRange_FailsWithArgumentOutOfRangeException(string timeout)
+        {
+            // Arrange
+            var sut = new EventConsumerHost(new ConsoleLogger());
+
+            // Act / Assert
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => sut.GetReceivedEvent(eventId: Guid.NewGuid().ToString(), timeout: TimeSpan.Parse(timeout)));
+        }
+    }
+}


### PR DESCRIPTION
We already have a 'GetReceivedEvent' method with a retry count as parameter to define more reliable assertions; but after consideration this would benefit to have a overload that takes a timeout instead of a retry count.

With this, the tester doesn't have to worry about internal retry cylces but can instead think about what a reasonable time range would be for the test.

#52