### PR TITLE
FEAT: add overload with Uri for EventGridPublisherBuilder

### DIFF
--- a/src/Arcus.EventGrid.Publishing/EventGridPublisher.cs
+++ b/src/Arcus.EventGrid.Publishing/EventGridPublisher.cs
@@ -24,7 +24,7 @@ namespace Arcus.EventGrid.Publishing
         /// </summary>
         /// <param name="topicEndpoint">Url of the custom Event Grid topic</param>
         /// <param name="authenticationKey">Authentication key for the custom Event Grid topic</param>
-        internal EventGridPublisher(string topicEndpoint, string authenticationKey)
+        internal EventGridPublisher(Uri topicEndpoint, string authenticationKey)
             : this(topicEndpoint, authenticationKey, Policy.NoOpAsync())
         {
         }
@@ -35,13 +35,13 @@ namespace Arcus.EventGrid.Publishing
         /// <param name="topicEndpoint">Url of the custom Event Grid topic</param>
         /// <param name="authenticationKey">Authentication key for the custom Event Grid topic</param>
         /// <param name="resilientPolicy">The policy to use making the publishing resilient.</param>
-        internal EventGridPublisher(string topicEndpoint, string authenticationKey, Policy resilientPolicy)
+        internal EventGridPublisher(Uri topicEndpoint, string authenticationKey, Policy resilientPolicy)
         {
-            Guard.NotNullOrWhitespace(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must not be empty and is required");
+            Guard.NotNull(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must be specified");
             Guard.NotNullOrWhitespace(authenticationKey, nameof(authenticationKey), "The authentication key must not be empty and is required");
             Guard.NotNull(resilientPolicy, nameof(resilientPolicy), "The resilient policy is required with this construction, otherwise use other constructor");
 
-            TopicEndpoint = topicEndpoint;
+            TopicEndpoint = topicEndpoint.OriginalString;
 
             _authenticationKey = authenticationKey;
             _resilientPolicy = resilientPolicy;

--- a/src/Arcus.EventGrid.Publishing/EventGridPublisher.cs
+++ b/src/Arcus.EventGrid.Publishing/EventGridPublisher.cs
@@ -24,7 +24,7 @@ namespace Arcus.EventGrid.Publishing
         /// </summary>
         /// <param name="topicEndpoint">Url of the custom Event Grid topic</param>
         /// <param name="authenticationKey">Authentication key for the custom Event Grid topic</param>
-        internal EventGridPublisher(Uri topicEndpoint, string authenticationKey)
+        internal EventGridPublisher(string topicEndpoint, string authenticationKey)
             : this(topicEndpoint, authenticationKey, Policy.NoOpAsync())
         {
         }
@@ -35,13 +35,13 @@ namespace Arcus.EventGrid.Publishing
         /// <param name="topicEndpoint">Url of the custom Event Grid topic</param>
         /// <param name="authenticationKey">Authentication key for the custom Event Grid topic</param>
         /// <param name="resilientPolicy">The policy to use making the publishing resilient.</param>
-        internal EventGridPublisher(Uri topicEndpoint, string authenticationKey, Policy resilientPolicy)
+        internal EventGridPublisher(string topicEndpoint, string authenticationKey, Policy resilientPolicy)
         {
-            Guard.NotNull(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must be specified");
+            Guard.NotNullOrWhitespace(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must not be empty and is required");
             Guard.NotNullOrWhitespace(authenticationKey, nameof(authenticationKey), "The authentication key must not be empty and is required");
             Guard.NotNull(resilientPolicy, nameof(resilientPolicy), "The resilient policy is required with this construction, otherwise use other constructor");
 
-            TopicEndpoint = topicEndpoint.OriginalString;
+            TopicEndpoint = topicEndpoint;
 
             _authenticationKey = authenticationKey;
             _resilientPolicy = resilientPolicy;

--- a/src/Arcus.EventGrid.Publishing/EventGridPublisher.cs
+++ b/src/Arcus.EventGrid.Publishing/EventGridPublisher.cs
@@ -24,6 +24,7 @@ namespace Arcus.EventGrid.Publishing
         /// </summary>
         /// <param name="topicEndpoint">Url of the custom Event Grid topic</param>
         /// <param name="authenticationKey">Authentication key for the custom Event Grid topic</param>
+        /// <exception cref="UriFormatException">The topic endpoint must be a HTTP endpoint.</exception>
         internal EventGridPublisher(Uri topicEndpoint, string authenticationKey)
             : this(topicEndpoint, authenticationKey, Policy.NoOpAsync())
         {
@@ -35,11 +36,16 @@ namespace Arcus.EventGrid.Publishing
         /// <param name="topicEndpoint">Url of the custom Event Grid topic</param>
         /// <param name="authenticationKey">Authentication key for the custom Event Grid topic</param>
         /// <param name="resilientPolicy">The policy to use making the publishing resilient.</param>
+        /// <exception cref="UriFormatException">The topic endpoint must be a HTTP endpoint.</exception>
         internal EventGridPublisher(Uri topicEndpoint, string authenticationKey, Policy resilientPolicy)
         {
             Guard.NotNull(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must be specified");
             Guard.NotNullOrWhitespace(authenticationKey, nameof(authenticationKey), "The authentication key must not be empty and is required");
             Guard.NotNull(resilientPolicy, nameof(resilientPolicy), "The resilient policy is required with this construction, otherwise use other constructor");
+            Guard.For<UriFormatException>(
+                () => topicEndpoint.Scheme != Uri.UriSchemeHttp
+                      && topicEndpoint.Scheme != Uri.UriSchemeHttps,
+                $"The topic endpoint must be and HTTP or HTTPS endpoint but is: {topicEndpoint.Scheme}");
 
             TopicEndpoint = topicEndpoint.OriginalString;
 

--- a/src/Arcus.EventGrid.Publishing/EventGridPublisherBuilder.cs
+++ b/src/Arcus.EventGrid.Publishing/EventGridPublisherBuilder.cs
@@ -26,6 +26,7 @@ namespace Arcus.EventGrid.Publishing
         /// </summary>
         /// <param name="topicEndpoint">Url of the custom Event Grid topic</param>
         /// <exception cref="ArgumentException">The topic endpoint must not be empty and is required</exception>
+        /// <exception cref="UriFormatException">The topic endpoint must be a HTTP endpoint.</exception>
         private EventGridPublisherBuilder(Uri topicEndpoint)
         {
             Guard.NotNull(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must be specified");
@@ -42,7 +43,7 @@ namespace Arcus.EventGrid.Publishing
         /// </summary>
         /// <param name="topicEndpoint">Url of the custom Event Grid topic</param>
         /// <exception cref="ArgumentException">The topic endpoint must not be empty and is required</exception>
-        /// <returns></returns>
+        /// <exception cref="UriFormatException">The topic endpoint must be a HTTP endpoint.</exception>
         /// <example>
         /// Shows how a <see cref="EventGridPublisher"/> should be created.
         /// <code>
@@ -57,21 +58,20 @@ namespace Arcus.EventGrid.Publishing
         {
             Guard.NotNullOrWhitespace(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must not be empty and is required");
 
-            if (Uri.TryCreate(topicEndpoint, UriKind.RelativeOrAbsolute, out Uri result))
-            {
-                return ForTopic(result);
-            }
+            bool isValidUri = Uri.TryCreate(topicEndpoint, UriKind.RelativeOrAbsolute, out Uri result);
+            Guard.For<UriFormatException>(
+                () => !isValidUri, 
+                $"Topic endpoint {topicEndpoint} was not in a correct format, please provide a HTTP or HTTPS topic endpoint");
 
-            throw new UriFormatException(
-                "Topic endpoint was not in a correct format, please provide a HTTP or HTTPS topic endpoint");
+            return ForTopic(result);
         }
 
         /// <summary>
-        /// Specifies the custom Event Grid <paramref name="topicEndpoint"/> for which a <see cref="EventGridPublisher"/> will be created.
+        ///     Specifies the custom Event Grid <paramref name="topicEndpoint"/> for which a <see cref="EventGridPublisher"/> will be created.
         /// </summary>
         /// <param name="topicEndpoint">Url of the custom Event Grid topic</param>
         /// <exception cref="ArgumentException">The topic endpoint must not be empty and is required</exception>
-        /// <returns></returns>
+        /// <exception cref="UriFormatException">The topic endpoint must be a HTTP endpoint.</exception>
         /// <example>
         /// Shows how a <see cref="EventGridPublisher"/> should be created.
         /// <code>
@@ -103,6 +103,7 @@ namespace Arcus.EventGrid.Publishing
         /// Finalized builder result that can directly create <see cref="EventGridPublisher"/> instances 
         /// via the <see cref="IBuilder.Build()"/> method or extend the publisher even further.
         /// </returns>
+        /// <exception cref="ArgumentException">The authentication key must not be empty and is required.</exception>
         public IEventGridPublisherBuilderWithExponentialRetry UsingAuthenticationKey(string authenticationKey)
         {
             Guard.NotNullOrWhitespace(authenticationKey, nameof(authenticationKey), "The authentication key must not be empty and is required");

--- a/src/Arcus.EventGrid.Publishing/EventGridPublisherBuilder.cs
+++ b/src/Arcus.EventGrid.Publishing/EventGridPublisherBuilder.cs
@@ -12,27 +12,23 @@ namespace Arcus.EventGrid.Publishing
     /// <code>
     /// EventGridPublisher myPublisher =
     ///     EventGridPublisherBuilder
-    ///         .ForTopic("http://myTopic")
+    ///         .ForTopic("myTopic")
     ///         .UsingAuthenticationKey("myAuthenticationKey")
     ///         .Build();
     /// </code>
     /// </example>
     public class EventGridPublisherBuilder : IEventGridPublisherBuilderWithAuthenticationKey
     {
-        private readonly Uri _topicEndpoint;
+        private readonly string _topicEndpoint;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EventGridPublisherBuilder"/> class.
         /// </summary>
         /// <param name="topicEndpoint">Url of the custom Event Grid topic</param>
         /// <exception cref="ArgumentException">The topic endpoint must not be empty and is required</exception>
-        private EventGridPublisherBuilder(Uri topicEndpoint)
+        private EventGridPublisherBuilder(string topicEndpoint)
         {
-            Guard.NotNull(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must be specified");
-            Guard.For<UriFormatException>(
-                () => topicEndpoint.Scheme != Uri.UriSchemeHttp
-                      && topicEndpoint.Scheme != Uri.UriSchemeHttps,
-                $"The topic endpoint must be and HTTP or HTTPS endpoint but is: {topicEndpoint.Scheme}");
+            Guard.NotNullOrWhitespace(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must not be empty and is required");
 
             _topicEndpoint = topicEndpoint;
         }
@@ -48,7 +44,7 @@ namespace Arcus.EventGrid.Publishing
         /// <code>
         /// EventGridPublisher myPublisher =
         ///     EventGridPublisherBuilder
-        ///         .ForTopic("http://myTopic")
+        ///         .ForTopic("myTopic")
         ///         .UsingAuthenticationKey("myAuthenticationKey")
         ///         .Build();
         /// </code>
@@ -57,50 +53,17 @@ namespace Arcus.EventGrid.Publishing
         {
             Guard.NotNullOrWhitespace(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must not be empty and is required");
 
-            if (Uri.TryCreate(topicEndpoint, UriKind.RelativeOrAbsolute, out Uri result))
-            {
-                return ForTopic(result);
-            }
-
-            throw new UriFormatException(
-                "Topic endpoint was not in a correct format, please provide a HTTP or HTTPS topic endpoint");
-        }
-
-        /// <summary>
-        /// Specifies the custom Event Grid <paramref name="topicEndpoint"/> for which a <see cref="EventGridPublisher"/> will be created.
-        /// </summary>
-        /// <param name="topicEndpoint">Url of the custom Event Grid topic</param>
-        /// <exception cref="ArgumentException">The topic endpoint must not be empty and is required</exception>
-        /// <returns></returns>
-        /// <example>
-        /// Shows how a <see cref="EventGridPublisher"/> should be created.
-        /// <code>
-        /// EventGridPublisher myPublisher =
-        ///     EventGridPublisherBuilder
-        ///         .ForTopic("http://myTopic")
-        ///         .UsingAuthenticationKey("myAuthenticationKey")
-        ///         .Build();
-        /// </code>
-        /// </example>
-        public static EventGridPublisherBuilder ForTopic(Uri topicEndpoint)
-        {
-            Guard.NotNull(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must be specified");
-            Guard.For<UriFormatException>(
-                () => topicEndpoint.Scheme != Uri.UriSchemeHttp
-                      && topicEndpoint.Scheme != Uri.UriSchemeHttps,
-                $"The topic endpoint must be and HTTP or HTTPS endpoint but is: {topicEndpoint.Scheme}");
-
             return new EventGridPublisherBuilder(topicEndpoint);
         }
 
         /// <summary>
         /// Specifies the <paramref name="authenticationKey"/> 
-        /// for the custom Event Grid topic for Which a <see cref="EventGridPublisher"/> will be created.
+        /// for the custom Event Grid topic for whcih a <see cref="EventGridPublisher"/> will be created.
         /// </summary>
         /// <param name="authenticationKey">Authentication key for the custom Event Grid topic</param>
         /// <exception cref="ArgumentException">The authentication key must not be empty and is required</exception>
         /// <returns>
-        /// Finalized builder result that can directly create <see cref="EventGridPublisher"/> instances 
+        /// Finilized builder result that can directly create <see cref="EventGridPublisher"/> instances 
         /// via the <see cref="IBuilder.Build()"/> method or extend the publisher even further.
         /// </returns>
         public IEventGridPublisherBuilderWithExponentialRetry UsingAuthenticationKey(string authenticationKey)

--- a/src/Arcus.EventGrid.Publishing/EventGridPublisherBuilder.cs
+++ b/src/Arcus.EventGrid.Publishing/EventGridPublisherBuilder.cs
@@ -57,13 +57,7 @@ namespace Arcus.EventGrid.Publishing
         public static EventGridPublisherBuilder ForTopic(string topicEndpoint)
         {
             Guard.NotNullOrWhitespace(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must not be empty and is required");
-
-            bool isValidUri = Uri.TryCreate(topicEndpoint, UriKind.RelativeOrAbsolute, out Uri result);
-            Guard.For<UriFormatException>(
-                () => !isValidUri, 
-                $"Topic endpoint {topicEndpoint} was not in a correct format, please provide a HTTP or HTTPS topic endpoint");
-
-            return ForTopic(result);
+            return ForTopic(new Uri(topicEndpoint));
         }
 
         /// <summary>

--- a/src/Arcus.EventGrid.Publishing/EventGridPublisherBuilderResult.cs
+++ b/src/Arcus.EventGrid.Publishing/EventGridPublisherBuilderResult.cs
@@ -26,7 +26,7 @@ namespace Arcus.EventGrid.Publishing
         /// <exception cref="ArgumentException">The topic endpoint must not be empty and is required</exception>
         /// <exception cref="ArgumentException">The authentication key must not be empty and is required</exception>
         /// <exception cref="UriFormatException">The topic endpoint must be a HTTP endpoint.</exception>
-        public EventGridPublisherBuilderResult(Uri topicEndpoint, string authenticationKey)
+        internal EventGridPublisherBuilderResult(Uri topicEndpoint, string authenticationKey)
             : this(topicEndpoint, authenticationKey, Policy.NoOpAsync())
         {
         }
@@ -41,7 +41,7 @@ namespace Arcus.EventGrid.Publishing
         /// <exception cref="ArgumentException">The authentication key must not be empty and is required</exception>
         /// <exception cref="ArgumentNullException">The resilient policy is required</exception>
         /// <exception cref="UriFormatException">The topic endpoint must be a HTTP endpoint.</exception>
-        public EventGridPublisherBuilderResult(
+        internal EventGridPublisherBuilderResult(
             Uri topicEndpoint,
             string authenticationKey,
             Policy resilientPolicy)

--- a/src/Arcus.EventGrid.Publishing/EventGridPublisherBuilderResult.cs
+++ b/src/Arcus.EventGrid.Publishing/EventGridPublisherBuilderResult.cs
@@ -8,13 +8,13 @@ using Polly.NoOp;
 namespace Arcus.EventGrid.Publishing
 {
     /// <summary>
-    ///     Result of the minimum required values to create <see cref="EventGridPublisher" /> instances, but also start-point of
+    ///     Result of the minimum required values to create <see cref="EventGridPublisher" /> instances, but also startpoint of
     ///     extending the instance.
     ///     The required and optional values are therefore split in separate classes and cannot be manipulated with casting.
     /// </summary>
     internal class EventGridPublisherBuilderResult : IEventGridPublisherBuilderWithExponentialRetry
     {
-        private readonly Uri _topicEndpoint;
+        private readonly string _topicEndpoint;
         private readonly string _authenticationKey;
         private readonly Policy _resilientPolicy;
 
@@ -25,7 +25,7 @@ namespace Arcus.EventGrid.Publishing
         /// <param name="authenticationKey">Authentication key for the custom Event Grid topic</param>
         /// <exception cref="ArgumentException">The topic endpoint must not be empty and is required</exception>
         /// <exception cref="ArgumentException">The authentication key must not be empty and is required</exception>
-        public EventGridPublisherBuilderResult(Uri topicEndpoint, string authenticationKey)
+        public EventGridPublisherBuilderResult(string topicEndpoint, string authenticationKey)
             : this(topicEndpoint, authenticationKey, Policy.NoOpAsync())
         {
         }
@@ -40,21 +40,17 @@ namespace Arcus.EventGrid.Publishing
         /// <exception cref="ArgumentException">The authentication key must not be empty and is required</exception>
         /// <exception cref="ArgumentNullException">The resilient policy is required</exception>
         public EventGridPublisherBuilderResult(
-            Uri topicEndpoint,
+            string topicEndpoint,
             string authenticationKey,
             Policy resilientPolicy)
         {
-            Guard.NotNull(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must be specified");
+            Guard.NotNullOrWhitespace(topicEndpoint, nameof(topicEndpoint), "The topic endpoint must not be empty and is required");
             Guard.NotNullOrWhitespace(authenticationKey, nameof(authenticationKey), "The authentication key must not be empty and is required");
             Guard.NotNull(resilientPolicy, nameof(resilientPolicy), "The resilient policy is required via this construction, use other constructor otherwise");
-            Guard.For<UriFormatException>(
-                () => topicEndpoint.Scheme != Uri.UriSchemeHttp
-                      && topicEndpoint.Scheme != Uri.UriSchemeHttps,
-                $"The topic endpoint must be and HTTP or HTTPS endpoint but is: {topicEndpoint.Scheme}");
 
             /* TODO:
              * shouldn't the `topicEndpoint` and the `authenticationKey` be domain models
-             * instead of primitives so we can centralize these validations (and possible others)
+             * instead of primitives so we can centrilize these validations (and possible others)
              * and not 'wait' till the 'Publish() throws? */
 
             _topicEndpoint = topicEndpoint;
@@ -64,7 +60,7 @@ namespace Arcus.EventGrid.Publishing
 
         /// <summary>
         ///     Makes the <see cref="IEventGridPublisher" /> resilient by retrying <paramref name="retryCount" /> times with
-        ///     exponential back-off.
+        ///     exponential backoff.
         /// </summary>
         /// <typeparam name="TException">The type of the exception that has to be retired.</typeparam>
         /// <param name="retryCount">The amount of retries should happen when a failure occurs during the publishing.</param>

--- a/src/Arcus.EventGrid.Publishing/Interfaces/IEventGridPublisherBuilderWithAuthenticationKey.cs
+++ b/src/Arcus.EventGrid.Publishing/Interfaces/IEventGridPublisherBuilderWithAuthenticationKey.cs
@@ -3,7 +3,8 @@
 namespace Arcus.EventGrid.Publishing.Interfaces
 {
     /// <summary>
-    /// Intermediary builder contract after the <see cref="EventGridPublisherBuilder.ForTopic"/> is called.
+    /// Intermediary builder contract after the <see cref="EventGridPublisherBuilder.ForTopic(string)"/>
+    /// or <see cref="EventGridPublisherBuilder.ForTopic(Uri)"/> is called.
     /// </summary>
     /// <remarks>
     /// This interface is not explicitly necessary at the moment but could be after there exists another correct way of creating 
@@ -13,7 +14,7 @@ namespace Arcus.EventGrid.Publishing.Interfaces
     {
         /// <summary>
         /// Specifies the <paramref name="authenticationKey"/> 
-        /// for the custom Event Grid topic for whcih a <see cref="EventGridPublisher"/> will be created.
+        /// for the custom Event Grid topic for Which a <see cref="EventGridPublisher"/> will be created.
         /// </summary>
         /// <param name="authenticationKey">Authentication key for the custom Event Grid topic</param>
         /// <exception cref="ArgumentException">The authentication key must not be empty and is required</exception>
@@ -21,6 +22,7 @@ namespace Arcus.EventGrid.Publishing.Interfaces
         /// Finalized builder result that can directly create <see cref="EventGridPublisher"/> instances 
         /// via the <see cref="IBuilder.Build()"/> method or extend the publisher even further.
         /// </returns>
+        /// <exception cref="ArgumentException">The authentication key must not be empty and is required.</exception>
         IEventGridPublisherBuilderWithExponentialRetry UsingAuthenticationKey(string authenticationKey);
     }
 }

--- a/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherBuilderTests.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherBuilderTests.cs
@@ -24,7 +24,7 @@ namespace Arcus.EventGrid.Tests.Unit.Publishing
         [InlineData("test.be")]
         public void ForTopic_NonUriEndpointTopic_ShouldFailWithInvalidOperationException(string topic)
         {
-            Assert.Throws<InvalidOperationException>(() => EventGridPublisherBuilder.ForTopic(topic));
+            Assert.Throws<UriFormatException>(() => EventGridPublisherBuilder.ForTopic(topic));
         }
 
         [Theory]

--- a/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherBuilderTests.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherBuilderTests.cs
@@ -19,6 +19,24 @@ namespace Arcus.EventGrid.Tests.Unit.Publishing
         }
 
         [Theory]
+        [InlineData("something not a HTTP endpoint ☺")]
+        [InlineData("11304-asdf-123123-sdafsd")]
+        [InlineData("test.be")]
+        public void ForTopic_NonUriEndpointTopic_ShouldFailWithInvalidOperationException(string topic)
+        {
+            Assert.Throws<InvalidOperationException>(() => EventGridPublisherBuilder.ForTopic(topic));
+        }
+
+        [Theory]
+        [InlineData("sftp://some-FTPS-uri")]
+        [InlineData("file:///C:\\temp\\dir")]
+        [InlineData("net.tcp://localhost:55509")]
+        public void ForTopic_NonHttpEndpointTopic_ShouldFailWithUriFormatException(string topic)
+        {
+            Assert.Throws<UriFormatException>(() => EventGridPublisherBuilder.ForTopic(topic));
+        }
+
+        [Theory]
         [InlineData(null)]
         [InlineData("")]
         [InlineData(" ")]

--- a/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherBuilderTests.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherBuilderTests.cs
@@ -19,24 +19,6 @@ namespace Arcus.EventGrid.Tests.Unit.Publishing
         }
 
         [Theory]
-        [InlineData("something not a HTTP endpoint ☺")]
-        [InlineData("11304-asdf-123123-sdafsd")]
-        [InlineData("test.be")]
-        public void ForTopic_NonUriEndpointTopic_ShouldFailWithInvalidOperationException(string topic)
-        {
-            Assert.Throws<InvalidOperationException>(() => EventGridPublisherBuilder.ForTopic(topic));
-        }
-
-        [Theory]
-        [InlineData("sftp://some-FTPS-uri")]
-        [InlineData("file:///C:\\temp\\dir")]
-        [InlineData("net.tcp://localhost:55509")]
-        public void ForTopic_NonHttpEndpointTopic_ShouldFailWithUriFormatException(string topic)
-        {
-            Assert.Throws<UriFormatException>(() => EventGridPublisherBuilder.ForTopic(topic));
-        }
-
-        [Theory]
         [InlineData(null)]
         [InlineData("")]
         [InlineData(" ")]

--- a/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherBuilderTests.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherBuilderTests.cs
@@ -47,6 +47,24 @@ namespace Arcus.EventGrid.Tests.Unit.Publishing
         }
 
         [Theory]
+        [InlineData("http://some-http-topic-endpoint")]
+        [InlineData("http://some-https-topic-endpoint")]
+        [InlineData(SampleTopicEndpoint)]
+        public void ForTopic_HttpEndpointTopic_WithUriOverload_ShouldCreatePublisher(string topic)
+        {
+            var uri = new Uri(topic);
+            IEventGridPublisher publisher = 
+                EventGridPublisherBuilder
+                    .ForTopic(uri)
+                    .UsingAuthenticationKey(SampleAuthenticationKey)
+                    .Build();
+
+            Assert.NotNull(publisher);
+            Assert.IsType<EventGridPublisher>(publisher);
+            Assert.Equal(topic, publisher.TopicEndpoint);
+        }
+
+        [Theory]
         [InlineData(null)]
         [InlineData("")]
         [InlineData(" ")]

--- a/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherBuilderTests.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherBuilderTests.cs
@@ -37,6 +37,16 @@ namespace Arcus.EventGrid.Tests.Unit.Publishing
         }
 
         [Theory]
+        [InlineData("sftp://some-FTPS-uri")]
+        [InlineData("file:///C:\\temp\\dir")]
+        [InlineData("net.tcp://localhost:55509")]
+        public void ForTopic_NonHttpEndpointTopic_WitUriOverload_ShouldFailWithUriFormatException(string topic)
+        {
+            var uri = new Uri(topic);
+            Assert.Throws<UriFormatException>(() => EventGridPublisherBuilder.ForTopic(uri));
+        }
+
+        [Theory]
         [InlineData(null)]
         [InlineData("")]
         [InlineData(" ")]

--- a/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherTests.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherTests.cs
@@ -13,7 +13,7 @@ namespace Arcus.EventGrid.Tests.Unit.Publishing
         public async Task Publish_NoEventSpecified_ShouldFailWithArgumentNullException()
         {
             // Arrange
-            const string topicEndpoint = "myTopic";
+            const string topicEndpoint = "http://myTopic";
             const string authenticationKey = "myKey";
             NewCarRegistered @event = null;
 
@@ -32,7 +32,7 @@ namespace Arcus.EventGrid.Tests.Unit.Publishing
         public async Task Publish_NoEventsSpecified_ShouldFailWithArgumentNullException()
         {
             // Arrange
-            const string topicEndpoint = "myTopic";
+            const string topicEndpoint = "https://myTopic";
             const string authenticationKey = "myKey";
             List<NewCarRegistered> events = null;
 
@@ -51,7 +51,7 @@ namespace Arcus.EventGrid.Tests.Unit.Publishing
         public async Task Publish_EmptyCollectionOfEventsSpecified_ShouldFailWithArgumentException()
         {
             // Arrange
-            const string topicEndpoint = "myTopic";
+            const string topicEndpoint = "http://myTopic";
             const string authenticationKey = "myKey";
             List<NewCarRegistered> events = new List<NewCarRegistered>();
 

--- a/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherTests.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Publishing/EventGridPublisherTests.cs
@@ -13,7 +13,7 @@ namespace Arcus.EventGrid.Tests.Unit.Publishing
         public async Task Publish_NoEventSpecified_ShouldFailWithArgumentNullException()
         {
             // Arrange
-            const string topicEndpoint = "http://myTopic";
+            const string topicEndpoint = "myTopic";
             const string authenticationKey = "myKey";
             NewCarRegistered @event = null;
 
@@ -32,7 +32,7 @@ namespace Arcus.EventGrid.Tests.Unit.Publishing
         public async Task Publish_NoEventsSpecified_ShouldFailWithArgumentNullException()
         {
             // Arrange
-            const string topicEndpoint = "https://myTopic";
+            const string topicEndpoint = "myTopic";
             const string authenticationKey = "myKey";
             List<NewCarRegistered> events = null;
 
@@ -51,7 +51,7 @@ namespace Arcus.EventGrid.Tests.Unit.Publishing
         public async Task Publish_EmptyCollectionOfEventsSpecified_ShouldFailWithArgumentException()
         {
             // Arrange
-            const string topicEndpoint = "http://myTopic";
+            const string topicEndpoint = "myTopic";
             const string authenticationKey = "myKey";
             List<NewCarRegistered> events = new List<NewCarRegistered>();
 


### PR DESCRIPTION
FEAT: add overload with Uri for EventGridPublisherBuilder  …
Because we could validate on the right kind of HTTP URL that's been
given, we could _Fail Fast_ without waiting till the actual publishing
of events fails and warn the user during the actual configuration of the
builder.

Closes #24