### PR TITLE
DOC: add XML docs to nupkg

### DIFF
--- a/src/Arcus.EventGrid.All/Arcus.EventGrid.All.csproj
+++ b/src/Arcus.EventGrid.All/Arcus.EventGrid.All.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -8,8 +8,9 @@
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <PackageTags>Azure;Event Grid</PackageTags>
     <Authors>Arcus</Authors>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Provides capabilities to easily integrate with Azure Event Grid such as pushing events, endpoint authentication &amp; handshake, contracts and more</Description>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.EventGrid.Azure/Arcus.EventGrid.Azure.csproj
+++ b/src/Arcus.EventGrid.Azure/Arcus.EventGrid.Azure.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -11,8 +11,9 @@
     <PackageTags>Azure;Event Grid</PackageTags>
     <Company>Arcus</Company>
     <Authors>Arcus</Authors>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Provides contracts for Azure resource events</Description>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/src/Arcus.EventGrid.EventHubs/Arcus.EventGrid.EventHubs.csproj
+++ b/src/Arcus.EventGrid.EventHubs/Arcus.EventGrid.EventHubs.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -10,8 +10,9 @@
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <PackageTags>Azure;Event Grid</PackageTags>
     <Company>Arcus</Company>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Provides contracts for Azure Event Hubs events</Description>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.EventGrid.IoTHub/Arcus.EventGrid.IoTHub.csproj
+++ b/src/Arcus.EventGrid.IoTHub/Arcus.EventGrid.IoTHub.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -11,8 +11,9 @@
     <PackageTags>Azure;Event Grid</PackageTags>
     <Company>Arcus</Company>
     <Authors>Arcus</Authors>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Provides contracts for Azure IoT Hubs events</Description>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.EventGrid.Publishing/Arcus.EventGrid.Publishing.csproj
+++ b/src/Arcus.EventGrid.Publishing/Arcus.EventGrid.Publishing.csproj
@@ -11,8 +11,9 @@
     <PackageTags>Azure;Event Grid</PackageTags>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Provides capability to push events to Azure Event Grid</Description>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.EventGrid.Security/Arcus.EventGrid.Security.csproj
+++ b/src/Arcus.EventGrid.Security/Arcus.EventGrid.Security.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -10,8 +10,9 @@
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <PackageTags>Azure;Event Grid</PackageTags>
     <Company>Arcus</Company>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Provides capability to simplify the authentication and endpoint handshake for Azure Event Grid</Description>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.EventGrid.Storage/Arcus.EventGrid.Storage.csproj
+++ b/src/Arcus.EventGrid.Storage/Arcus.EventGrid.Storage.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -10,8 +10,9 @@
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <PackageTags>Azure;Event Grid</PackageTags>
     <Authors>Arcus</Authors>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Provides contracts for Azure Storage events</Description>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.EventGrid.Testing/Arcus.EventGrid.Testing.csproj
+++ b/src/Arcus.EventGrid.Testing/Arcus.EventGrid.Testing.csproj
@@ -10,6 +10,7 @@
     <PackageTags>Azure;Event Grid;Testing</PackageTags>
     <Description>Provides infrastructure to build automated testing with Azure Event Grid.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.EventGrid/Arcus.EventGrid.csproj
+++ b/src/Arcus.EventGrid/Arcus.EventGrid.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,10 +9,11 @@
     <PackageProjectUrl>https://github.com/arcus-azure/arcus.eventgrid</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.eventgrid/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>Azure;Event Grid</PackageTags>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <Copyright>Copyright (c) Arcus</Copyright>
     <Description>Provides core capabilities for using Event Grid with Arcus</Description>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
During the build of the NuGet packages, the XML docs weren't part of the
package. Meaning no docs during development.

This commit lets the projects generate such a documentation file
which will automatically be part of the also automatically generate NuGet package.