### PR TITLE
DOC: fix broken backwards arrow

### DIFF
--- a/docs/features/deserializing-events.md
+++ b/docs/features/deserializing-events.md
@@ -30,4 +30,4 @@ When using official Azure events, you can use `.ParseFromData<>` to deserialize 
 EventGridBatch<EventGridEvent<StorageBlobCreatedEventData>> eventGridBatch = EventGridParser.ParseFromData<StorageBlobCreatedEventData>(rawEvent);
 ```
 
-[&larr; back](/arcus.eventgrid)
+[&larr; back](/)

--- a/docs/features/endpoint-validation.md
+++ b/docs/features/endpoint-validation.md
@@ -49,4 +49,4 @@ Important for this authorization method to work, is to set the static property `
 DynamicEventGridAuthorizationAttribute.RetrieveAuthenticationSecret = () => Task.FromResult("my-secret-key");
 ```
 
-[&larr; back](/arcus.eventgrid)
+[&larr; back](/)

--- a/docs/features/running-integration-tests.md
+++ b/docs/features/running-integration-tests.md
@@ -124,4 +124,4 @@ var serviceBusEventConsumerHostOptions = new ServiceBusEventConsumerHostOptions(
 };
 ```
 
-[&larr; back](/arcus.eventgrid)
+[&larr; back](/)


### PR DESCRIPTION
Apperently some feature docs had a diff backwards arrow; leading to a broken page.
Fixed by removing the unnecessary trailing `/arcus.eventgrid`.