### PR TITLE
WIP: FIX: parse CloudEvent's without 'cloudEventsVersion' property

### DIFF
--- a/src/Arcus.EventGrid.Tests.Unit/Artifacts/EventSamples.Designer.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Artifacts/EventSamples.Designer.cs
@@ -143,6 +143,15 @@ namespace Arcus.EventGrid.Tests.Unit.Artifacts {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to [{&quot;id&quot;:&quot;c041a355-5a1d-4ada-b562-e80f73e1f315&quot;,&quot;source&quot;:&quot;/subscriptions/76126fd3-49df-5d7e-a74f-9d638f94a1e6/resourceGroups/arcus/providers/Microsoft.KeyVault/vaults/arcus&quot;,&quot;specversion&quot;:&quot;1.0&quot;,&quot;type&quot;:&quot;Microsoft.KeyVault.SecretNewVersionCreated&quot;,&quot;dataschema&quot;:&quot;#1&quot;,&quot;subject&quot;:&quot;81fdcb24317034asdf119b2ef83335f13a837&quot;,&quot;time&quot;:&quot;2020-01-10T07:00:21.1747955Z&quot;,&quot;data&quot;:&quot;{\&quot;Id\&quot;:\&quot;https://arcus.vault.azure.net/secrets/81fdcb24317034asdf119b2ef83335f13a837/853c8c87asdfasdfasdf7dec439a8f59c88050d02e3fdab\&quot;,\&quot;VaultName\&quot;:\&quot;ar [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string NewSecretVersionCreatedCloudEvent {
+            get {
+                return ResourceManager.GetString("NewSecretVersionCreatedCloudEvent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [
         ///                  {
         ///                    &quot;id&quot;: &quot;2d1781af-3a4c-4d7c-bd0c-e34b19da4e66&quot;,

--- a/src/Arcus.EventGrid.Tests.Unit/Artifacts/EventSamples.resx
+++ b/src/Arcus.EventGrid.Tests.Unit/Artifacts/EventSamples.resx
@@ -260,6 +260,9 @@
   "metadataVersion": "1"
 }]</value>
   </data>
+  <data name="NewSecretVersionCreatedCloudEvent" xml:space="preserve">
+    <value>[{"id":"c041a355-5a1d-4ada-b562-e80f73e1f315","source":"/subscriptions/76126fd3-49df-5d7e-a74f-9d638f94a1e6/resourceGroups/arcus/providers/Microsoft.KeyVault/vaults/arcus","specversion":"1.0","type":"Microsoft.KeyVault.SecretNewVersionCreated","dataschema":"#1","subject":"81fdcb24317034asdf119b2ef83335f13a837","time":"2020-01-10T07:00:21.1747955Z","data":"{\"Id\":\"https://arcus.vault.azure.net/secrets/81fdcb24317034asdf119b2ef83335f13a837/853c8c87asdfasdfasdf7dec439a8f59c88050d02e3fdab\",\"VaultName\":\"arcus\",\"ObjectType\":\"Secret\",\"ObjectName\":\"81fdcb24317034asdf119b2ef83335f13a837\",\"Version\":\"853c8c87asdfasdfasdf7dec439a8f59c88050d02e3fdab\",\"NBF\":null,\"EXP\":null}"}]</value>
+  </data>
   <data name="SubscriptionValidationEvent" xml:space="preserve">
     <value>[
                   {

--- a/src/Arcus.EventGrid.Tests.Unit/Parsing/EventParsingTests.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Parsing/EventParsingTests.cs
@@ -152,6 +152,54 @@ namespace Arcus.EventGrid.Tests.Unit.Parsing
         }
 
         [Fact]
+        public void Parse_ValidNewSecretVersionCreatedCloudEvent_ShouldSucceed()
+        {
+            // Arrange
+            const CloudEventsSpecVersion cloudEventsVersion = CloudEventsSpecVersion.Default;
+            const string eventType = "Microsoft.KeyVault.SecretNewVersionCreated",
+                         source = "/subscriptions/76126fd3-49df-5d7e-a74f-9d638f94a1e6/resourceGroups/arcus/providers/Microsoft.KeyVault/vaults/arcus",
+                         eventId = "c041a355-5a1d-4ada-b562-e80f73e1f315",
+                         eventTime = "2020-01-10T07:00:21.1747955Z",
+                         subject = "81fdcb24317034asdf119b2ef83335f13a837";
+
+            const string id = "https://arcus.vault.azure.net/secrets/81fdcb24317034asdf119b2ef83335f13a837/853c8c87asdfasdfasdf7dec439a8f59c88050d02e3fdab",
+                         vaultName = "arcus",
+                         objectName = "81fdcb24317034asdf119b2ef83335f13a837",
+                         objectType = "Secret",
+                         version = "853c8c87asdfasdfasdf7dec439a8f59c88050d02e3fdab",
+                         nbf = null,
+                         exp = null;
+
+            string rawEvent = EventSamples.NewSecretVersionCreatedCloudEvent;
+
+            // Act
+            EventGridEventBatch<Event> eventBatch = EventGridParser.Parse(rawEvent);
+            
+            // Assert
+            Assert.NotNull(eventBatch);
+            Assert.NotNull(eventBatch.Events);
+            
+            CloudEvent cloudEvent = Assert.Single(eventBatch.Events);
+            Assert.NotNull(cloudEvent);
+            Assert.NotNull(cloudEvent);
+            Assert.Equal(cloudEventsVersion, cloudEvent.SpecVersion);
+            Assert.Equal(eventType, cloudEvent.Type);
+            Assert.Equal(source, cloudEvent.Source.OriginalString);
+            Assert.Equal(eventId, cloudEvent.Id);
+            Assert.Equal(eventTime, cloudEvent.Time.GetValueOrDefault().ToString("O"));
+            Assert.Equal(subject, cloudEvent.Subject);
+
+            JObject eventPayload = JObject.Parse(cloudEvent.Data.ToString());
+            Assert.Equal(id, eventPayload.Property("Id").Value);
+            Assert.Equal(vaultName, eventPayload.Property("VaultName").Value);
+            Assert.Equal(objectName, eventPayload.Property("ObjectName").Value);
+            Assert.Equal(objectType, eventPayload.Property("ObjectType").Value);
+            Assert.Equal(version, eventPayload.Property("Version").Value);
+            Assert.Equal(nbf, eventPayload.Property("NBF").Value);
+            Assert.Equal(exp, eventPayload.Property("EXP").Value);
+        }
+
+        [Fact]
         public void Parse_WithNullRawJsonEventBody_ShouldThrowArgumentException()
         {
             Assert.Throws<ArgumentException>(() => EventGridParser.Parse(rawJsonBody: null));

--- a/src/Arcus.EventGrid/Parsers/EventGridParser.cs
+++ b/src/Arcus.EventGrid/Parsers/EventGridParser.cs
@@ -119,7 +119,9 @@ namespace Arcus.EventGrid.Parsers
             {
                 var rawEvent = eventObject.ToString();
 
-                if (eventObject.ContainsKey("cloudEventsVersion"))
+                if (eventObject.ContainsKey("cloudEventsVersion")
+                    || eventObject.ContainsKey("specversion")
+                    || eventObject.ContainsKey("dataschema"))
                 {
                     var jsonFormatter = new JsonEventFormatter();
                     var cloudEvent = jsonFormatter.DecodeStructuredEvent(Encoding.UTF8.GetBytes(rawEvent));


### PR DESCRIPTION
Loads `CloudEvents` without the `cloudEventVersion` property, but with a `specversion` or `dataschema` (both not present in an `EventGrid` event).