### PR TITLE
feat: use new Azure SDK for testing package

### DIFF
--- a/src/Arcus.EventGrid.Testing/Arcus.EventGrid.Testing.csproj
+++ b/src/Arcus.EventGrid.Testing/Arcus.EventGrid.Testing.csproj
@@ -13,18 +13,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.2" />
-  </ItemGroup>
-
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.0.0" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Azure.Relay" Version="2.0.0-preview1-20180523" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
     <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
 

--- a/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/ServiceBus/ServiceBusEventConsumerHostOptions.cs
+++ b/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/ServiceBus/ServiceBusEventConsumerHostOptions.cs
@@ -1,42 +1,46 @@
-﻿using GuardNet;
+﻿using System;
+using GuardNet;
 
 namespace Arcus.EventGrid.Testing.Infrastructure.Hosts.ServiceBus
 {
     /// <summary>
-    ///     Configuration options for the <see cref="ServiceBusEventConsumerHost" />
+    /// Represents the configuration options for the <see cref="ServiceBusEventConsumerHost" />.
     /// </summary>
     public class ServiceBusEventConsumerHostOptions
     {
         /// <summary>
-        ///     Constructor
+        /// Initializes a new instance of the <see cref="ServiceBusEventConsumerHostOptions"/> class.
         /// </summary>
-        /// <param name="topicPath">Path of the topic relative to the namespace base address</param>
-        /// <param name="connectionString">
-        ///     Connection string of the Azure Service Bus namespace to use to consume
-        ///     messages
-        /// </param>
+        /// <param name="topicPath">The path of the Azure Service Bus topic relative to the Azure Service Bus namespace base address.</param>
+        /// <param name="connectionString">The connection string, scoped to the Azure Service Bus namespace to authenticate with the Azure Service Bus topic.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="topicPath"/> or the <paramref name="connectionString"/> is blank.</exception>
         public ServiceBusEventConsumerHostOptions(string topicPath, string connectionString)
         {
-            Guard.NotNullOrWhitespace(topicPath, nameof(topicPath));
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString));
+            Guard.NotNullOrWhitespace(topicPath, nameof(topicPath), "Requires a non-blank Azure Service Bus topic name to consume events");
+            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires a non-blank Azure Service Bus connection string, scoped to the Azure Service Bus namespace to authenticate with the topic");
 
             TopicPath = topicPath;
             ConnectionString = connectionString;
+            SubscriptionName = $"Test-{Guid.NewGuid()}";
         }
 
         /// <summary>
-        ///     Path of the topic relative to the namespace base address
+        /// Gets the Azure Service Bus topic name, relative to the namespace base address.
         /// </summary>
         public string TopicPath { get; }
 
         /// <summary>
-        ///     Connection string of the Azure Service Bus namespace to use to consume
-        ///     messages
+        /// Gets the Azure Service Bus topic subscription name, where the to-be-consumed events will be placed.
+        /// </summary>
+        public string SubscriptionName { get; }
+        
+        /// <summary>
+        /// Gets the connection string, scoped to the Azure Service Bus namespace to authenticate with the Azure Service Bus topic.
         /// </summary>
         public string ConnectionString { get; }
 
         /// <summary>
-        ///     Defines the behavior of the subscription on closure. (Defaults to delete)
+        /// Gets the the behavior of the Azure Service Bus topic subscription on closure. (Defaults to <see cref="ServiceBus.SubscriptionBehavior.DeleteOnClosure"/>)
         /// </summary>
         public SubscriptionBehavior SubscriptionBehavior { get; set; } = SubscriptionBehavior.DeleteOnClosure;
     }

--- a/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/ServiceBus/SubscriptionBehavior.cs
+++ b/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/ServiceBus/SubscriptionBehavior.cs
@@ -1,8 +1,20 @@
 ﻿namespace Arcus.EventGrid.Testing.Infrastructure.Hosts.ServiceBus
 {
+    /// <summary>
+    /// Represents the available options in behavior when Azure Service Bus topic subscriptions are managed during the lifetime of the <see cref="ServiceBusEventConsumerHost"/>.
+    /// </summary>
     public enum SubscriptionBehavior
     {
+        /// <summary>
+        /// Keeps all the Azure Service Bus topic subscriptions that were created during the lifetime of the <see cref="ServiceBusEventConsumerHost"/>
+        /// when the consumer host stops receiving traffic.
+        /// </summary>
         KeepOnClosure,
+        
+        /// <summary>
+        /// Deletes all the Azure Service Bus topic subscriptions that were created during the lifetime of the <see cref="ServiceBusEventConsumerHost"/>
+        /// when the consumer host stops receiving traffic.
+        /// </summary>
         DeleteOnClosure
     }
 }

--- a/src/Arcus.EventGrid.Testing/Logging/ConsoleLogger.cs
+++ b/src/Arcus.EventGrid.Testing/Logging/ConsoleLogger.cs
@@ -3,19 +3,40 @@ using Microsoft.Extensions.Logging;
 
 namespace Arcus.EventGrid.Testing.Logging
 {
+    /// <summary>
+    /// Represents an <see cref="ILogger"/> model that writes log messages towards the standard console output.
+    /// </summary>
     public class ConsoleLogger : ILogger
     {
+        /// <summary>
+        /// Writes a log entry.
+        /// </summary>
+        /// <param name="logLevel">The entry will be written on this level.</param>
+        /// <param name="eventId">The ID of the event.</param>
+        /// <param name="state">The entry to be written. Can be also an object.</param>
+        /// <param name="exception">The exception related to this entry.</param>
+        /// <param name="formatter">The function to create a <c>string</c> message of the <paramref name="state" /> and <paramref name="exception" />.</param>
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             var message = formatter(state, exception);
             Console.WriteLine($"{DateTimeOffset.UtcNow:s} {logLevel} > {message}");
         }
 
+        /// <summary>
+        /// Checks if the given <paramref name="logLevel" /> is enabled.
+        /// </summary>
+        /// <param name="logLevel">level to be checked.</param>
+        /// <returns><c>true</c> if enabled.</returns>
         public bool IsEnabled(LogLevel logLevel)
         {
             return true;
         }
 
+        /// <summary>
+        /// Begins a logical operation scope.
+        /// </summary>
+        /// <param name="state">The identifier for the scope.</param>
+        /// <returns>An IDisposable that ends the logical operation scope on dispose.</returns>
         public IDisposable BeginScope<TState>(TState state)
         {
             return null;

--- a/src/Arcus.EventGrid.Testing/Logging/NoOpLogger.cs
+++ b/src/Arcus.EventGrid.Testing/Logging/NoOpLogger.cs
@@ -3,18 +3,39 @@ using Microsoft.Extensions.Logging;
 
 namespace Arcus.EventGrid.Testing.Logging
 {
+    /// <summary>
+    /// Represents an <see cref="ILogger"/> model without any implementation.
+    /// </summary>
     public class NoOpLogger : ILogger
     {
+        /// <summary>
+        /// Writes a log entry.
+        /// </summary>
+        /// <param name="logLevel">The entry will be written on this level.</param>
+        /// <param name="eventId">The ID of the event.</param>
+        /// <param name="state">The entry to be written. Can be also an object.</param>
+        /// <param name="exception">The exception related to this entry.</param>
+        /// <param name="formatter">The function to create a <c>string</c> message of the <paramref name="state" /> and <paramref name="exception" />.</param>
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             // Deliberately don't log anything
         }
 
+        /// <summary>
+        /// Checks if the given <paramref name="logLevel" /> is enabled.
+        /// </summary>
+        /// <param name="logLevel">level to be checked.</param>
+        /// <returns><c>true</c> if enabled.</returns>
         public bool IsEnabled(LogLevel logLevel)
         {
             return false;
         }
 
+        /// <summary>
+        /// Begins a logical operation scope.
+        /// </summary>
+        /// <param name="state">The identifier for the scope.</param>
+        /// <returns>An IDisposable that ends the logical operation scope on dispose.</returns>
         public IDisposable BeginScope<TState>(TState state)
         {
             return null;


### PR DESCRIPTION
Use the new Azure SDK for the `Arcus.EventGrid.Testing` package. The .NET Core 2.2 support is not (yet) deleted here bc of possible(?) breaking changes if we release a next minor.

Closes #165 