### PR TITLE
fix: use ubuntu-latest for build pipelines

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -37,7 +37,7 @@ stages:
     jobs:
       - job: Compile
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - template: 'nuget/determine-pr-version.yml@templates'
             parameters:
@@ -70,7 +70,7 @@ stages:
       - job: UnitTests
         displayName: 'Run unit tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -95,7 +95,7 @@ stages:
       - job: IntegrationTests
         displayName: 'Run integration tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -122,7 +122,7 @@ stages:
       - job: PushToMyGet
         displayName: 'Push to MyGet'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -29,7 +29,7 @@ stages:
     jobs:
       - job: Compile
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: UseDotNet@2
             displayName: 'Import .NET Core SDK ($(DotNet.Sdk.VersionBC))'
@@ -59,7 +59,7 @@ stages:
       - job: UnitTests
         displayName: 'Run unit tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -84,7 +84,7 @@ stages:
       - job: IntegrationTests
         displayName: 'Run integration tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -111,7 +111,7 @@ stages:
       - job: PushRelease
         displayName: 'Push release'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'

--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -2,3 +2,4 @@ variables:
   DotNet.Sdk.Version: '3.1.201'
   DotNet.Sdk.VersionBC: '2.2.105'
   Project: 'Arcus.EventGrid'
+  Vm.Image: 'ubuntu-latest'


### PR DESCRIPTION
Use `ubuntu-latest` for the VM image in the build pipelines.

Relates to https://github.com/arcus-azure/arcus/issues/144