### PR TITLE
feat: add az event filters to test event consumer

### DIFF
--- a/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
+++ b/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
@@ -1,81 +1,126 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading.Tasks;
+using Arcus.EventGrid.Contracts;
+using Arcus.EventGrid.Parsers;
+using CloudNative.CloudEvents;
 using GuardNet;
+using Microsoft.Azure.EventGrid.Models;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Polly;
 
 namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
 {
     /// <summary>
+    /// Represents a 
+    /// </summary>
+    public class EventEntry
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventEntry" /> class.
+        /// </summary>
+        public EventEntry(string eventId, string eventPayload)
+        {
+            Guard.NotNull(eventId, nameof(eventId), "Requires a non-blank");
+        }
+        
+        public string EventId { get; }
+        public string EventPayload { get; }
+    }
+    
+    /// <summary>
     ///     Foundation for all event consumer hosts that handle Azure Event Grid events to be consumed in integration tests
     /// </summary>
     public class EventConsumerHost
     {
-        private static readonly ConcurrentDictionary<string, string> ReceivedEvents = new ConcurrentDictionary<string, string>();
-
+        // TODO: is 'static' correct here? Multiple event consumers should have different sets of received events, right?
+        private static readonly ConcurrentDictionary<string, EventEntry> ReceivedEvents = new ConcurrentDictionary<string, EventEntry>();
+        
         /// <summary>
         ///     Gets the logger associated with this event consumer.
         /// </summary>
         protected ILogger Logger { get; }
 
         /// <summary>
-        ///     Constructor
+        /// Initializes a new instance of the <see cref="EventConsumerHost"/> class.
         /// </summary>
-        /// <param name="logger">Logger to use for writing event information</param>
+        /// <param name="logger">The logger to use for writing event information of the received events.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         public EventConsumerHost(ILogger logger)
         {
-            Guard.NotNull(logger, nameof(logger));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write event information of the received events");
 
             Logger = logger;
         }
 
+        // TODO: is 'static' correct here? Couldn't we provide a instance member where we use the constructor-provided logger instead?
         /// <summary>
-        ///     Handles new events that are being received
+        /// Handles new received events into the event consumer that can later be retrieved.
         /// </summary>
-        /// <param name="rawReceivedEvents">Raw payload containing all events</param>
-        /// <param name="logger">Logger to use for writing event information</param>
+        /// <param name="rawReceivedEvents">The raw payload containing all received events.</param>
+        /// <param name="logger">The logger to use for writing event information of the received events.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawReceivedEvents"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="JsonReaderException">Thrown when the <paramref name="rawReceivedEvents"/> failed to be read as valid JSON.</exception>
         protected static void EventsReceived(string rawReceivedEvents, ILogger logger)
         {
-            Guard.NotNullOrWhitespace(rawReceivedEvents, nameof(rawReceivedEvents));
-
+            Guard.NotNullOrWhitespace(rawReceivedEvents, nameof(rawReceivedEvents), "Requires a non-blank raw event payload containing the serialized received events");
+            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write event information of the received events");
+            
             JToken jToken = JToken.Parse(rawReceivedEvents);
-            if (jToken.Type == JTokenType.Array)
+            if (jToken.Type is JTokenType.Array)
             {
                 foreach (JToken parsedEvent in jToken.Children())
                 {
                     SaveEvent(rawReceivedEvents, logger, parsedEvent);
                 }
             }
-            else if (jToken.Type == JTokenType.Object)
+            else if (jToken.Type is JTokenType.Object)
             {
                 SaveEvent(rawReceivedEvents, logger, jToken);
+            }
+            else
+            {
+                logger.LogWarning("Could not save event because it doesn't represents either a JSON array (multiple events) or object (single event): '{EventPayload}'", rawReceivedEvents);
             }
         }
 
         private static void SaveEvent(string rawReceivedEvents, ILogger logger, JToken parsedEvent)
         {
             string eventId = DetermineEventId(parsedEvent);
-            if (eventId == null)
+            if (eventId is null)
             {
-                logger.LogWarning($"Event was received without an event id. Payload : {parsedEvent}");
+                logger.LogWarning("Could not save event because event was received without an event ID and payload: {EventPayload}", parsedEvent);
             }
             else
             {
-                ReceivedEvents.AddOrUpdate(eventId, rawReceivedEvents, (key, value) => rawReceivedEvents);
+                logger.LogTrace("Received event with ID: {EventId} and payload: {EventPayload}", eventId, parsedEvent);
+                ReceivedEvents.AddOrUpdate(eventId, new EventEntry(eventId, rawReceivedEvents), (key, value) => new EventEntry(key, rawReceivedEvents));
             }
         }
 
         /// <summary>
-        ///     Gets the event envelope that includes a requested event (Uses exponential back-off)
+        /// Gets the event envelope that includes a requested event (uses exponential back-off).
         /// </summary>
-        /// <param name="eventId">Event id for requested event</param>
-        /// <param name="retryCount">Amount of retries while waiting for the event to come in</param>
+        /// <param name="eventId">The vent ID for requested event.</param>
+        /// <param name="retryCount">The amount of retries while waiting for the event to come in.</param>
+        /// <returns>
+        ///     The raw received event contents with the given <paramref name="eventId"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="eventId"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="retryCount"/> is a negative amount of retries.</exception>
+        /// <exception cref="TimeoutException">
+        ///     Thrown when the no event could be received with the exponential back-off of the given amount of <paramref name="retryCount"/>.
+        /// </exception>
         public string GetReceivedEvent(string eventId, int retryCount = 5)
         {
-            Guard.NotNullOrWhitespace(eventId, nameof(eventId));
-
+            Guard.NotNullOrWhitespace(eventId, nameof(eventId), "Requires a non-blank event ID to identify the consumed event");
+            Guard.NotLessThanOrEqualTo(retryCount, 0, nameof(retryCount), "Requires a positive amount of retries while waiting for the event to come in");
+            
             Policy<string> retryPolicy =
                 Policy.HandleResult<string>(String.IsNullOrWhiteSpace)
                       .WaitAndRetry(retryCount, currentRetryCount => TimeSpan.FromSeconds(Math.Pow(2, currentRetryCount)));
@@ -83,7 +128,7 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
             PolicyResult<string> result = 
                 retryPolicy.ExecuteAndCapture(() => TryGetReceivedEvent(eventId));
             
-            if (result.Outcome == OutcomeType.Failure)
+            if (result.Outcome is OutcomeType.Failure)
             {
                 throw new TimeoutException(
                     "Could not in the available retry counts receive an event from Event Grid on the Service Bus topic");
@@ -93,27 +138,141 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
         }
 
         /// <summary>
-        ///     Gets the event envelope that includes a requested event (Uses timeout)
+        /// Gets the event envelope that includes a requested event (uses timeout).
         /// </summary>
-        /// <param name="eventId">Event id for requested event</param>
-        /// <param name="timeout">Time period in which the event should be received.</param>
+        /// <param name="eventId">The event ID for requested event.</param>
+        /// <param name="timeout">The time period in which the event should be consumed.</param>
+        /// <returns>
+        ///     The raw received event contents with the given <paramref name="eventId"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="eventId"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="timeout"/> is a negative time range.</exception>
+        /// <exception cref="TimeoutException">
+        ///     Thrown when no event could be received within the specified <paramref name="timeout"/> time range with the given <paramref name="eventId"/>.
+        /// </exception>
         public string GetReceivedEvent(string eventId, TimeSpan timeout)
         {
-            Guard.NotNullOrWhitespace(eventId, nameof(eventId));
+            Guard.NotNullOrWhitespace(eventId, nameof(eventId), "Requires a non-blank event ID to identify the consumed event");
             Guard.NotLessThanOrEqualTo(timeout, TimeSpan.Zero, nameof(timeout), "Timeout should be representing a positive time range");
 
-            Policy<string> timeoutPolicy =
-                Policy.Timeout(timeout)
-                      .Wrap(Policy.HandleResult<string>(String.IsNullOrWhiteSpace)
-                                  .WaitAndRetryForever(retryCount => TimeSpan.FromSeconds(1)));
-
+            Policy<string> timeoutPolicy = 
+                CreateTimeoutPolicy<string>(String.IsNullOrWhiteSpace, timeout);
+            
             PolicyResult<string> result = 
                 timeoutPolicy.ExecuteAndCapture(() => TryGetReceivedEvent(eventId));
 
-            if (result.Outcome == OutcomeType.Failure)
+            if (result.Outcome is OutcomeType.Failure)
             {
                 throw new TimeoutException(
                     "Could not in the time available receive an event from Event Grid on the Service Bus topic");
+            }
+
+            return result.Result;
+        }
+        
+        /// <summary>
+        /// Gets the event envelope that includes a requested event (uses timeout).
+        /// </summary>
+        /// <param name="cloudEventFilter">The custom event filter to select a specific <see cref="CloudEvent"/> event.</param>
+        /// <param name="timeout">The time period in which the event should be consumed.</param>
+        /// <returns>
+        ///     The deserialized <see cref="CloudEvent"/> event that matches the specified <paramref name="cloudEventFilter"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cloudEventFilter"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="timeout"/> is a negative time range.</exception>
+        /// <exception cref="TimeoutException">
+        ///     Thrown when no event could be received within the specified <paramref name="timeout"/> time range that matches the given <paramref name="cloudEventFilter"/>.
+        /// </exception>
+        public CloudEvent GetReceivedEvent(Func<CloudEvent, bool> cloudEventFilter, TimeSpan timeout)
+        {
+            Guard.NotNull(cloudEventFilter, nameof(cloudEventFilter), "Requires a function to filter out received CloudEvent events");
+            Guard.NotLessThanOrEqualTo(timeout, TimeSpan.Zero, nameof(timeout), "Requires a timeout span representing a positive time range");
+
+            Policy<CloudEvent> timeoutPolicy = 
+                CreateTimeoutPolicy<CloudEvent>(ev => ev != null, timeout);
+            
+            PolicyResult<CloudEvent> result =
+                timeoutPolicy.ExecuteAndCapture(() => 
+                    TryGetReceivedEvent(ev => cloudEventFilter(ev)));
+
+            if (result.Outcome is OutcomeType.Failure)
+            {
+                throw new TimeoutException(
+                    $"Could not in the time available ({timeout:g}) receive an CloudEvent event from Azure Event Grid on the Service Bus topic that matches the given filter");
+            }
+
+            return result.Result;
+        }
+
+        /// <summary>
+        /// Gets the event envelope that includes a requested event (uses timeout).
+        /// </summary>
+        /// <param name="eventGridEventFilter">The custom event filter to select a specific <see cref="EventGridEvent"/> event.</param>
+        /// <param name="timeout">The time period in which the event should be consumed.</param>
+        /// <returns>
+        ///     The deserialized <see cref="EventGridEvent"/> event that matches the specified <paramref name="eventGridEventFilter"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="eventGridEventFilter"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="timeout"/> is a negative time range.</exception>
+        /// <exception cref="TimeoutException">
+        ///     Thrown when no event could be received within the specified <paramref name="timeout"/> time range that matches the given <paramref name="eventGridEventFilter"/>.
+        /// </exception>
+        public EventGridEvent GetReceivedEvent(Func<EventGridEvent, bool> eventGridEventFilter, TimeSpan timeout)
+        {
+            Guard.NotNull(eventGridEventFilter, nameof(eventGridEventFilter), "Requires a function to filter out received CloudEvent events");
+            Guard.NotLessThanOrEqualTo(timeout, TimeSpan.Zero, nameof(timeout), "Requires a timeout span representing a positive time range");
+
+            Policy<EventGridEvent> timeoutPolicy = 
+                CreateTimeoutPolicy<EventGridEvent>(ev => ev != null, timeout);
+            
+            PolicyResult<EventGridEvent> result =
+                timeoutPolicy.ExecuteAndCapture(() => 
+                    TryGetReceivedEvent(ev => eventGridEventFilter(ev)));
+
+            if (result.Outcome is OutcomeType.Failure)
+            {
+                throw new TimeoutException(
+                    $"Could not in the time available ({timeout:g}) receive an CloudEvent event from Azure Event Grid on the Service Bus topic that matches the given filter");
+            }
+
+            return result.Result;
+        }
+
+        /// <summary>
+        /// Gets the event envelope that includes the requested event (uses timeout).
+        /// </summary>
+        /// <typeparam name="TEventPayload">The custom event payload of the requested consumed event.</typeparam>
+        /// <param name="eventPayloadFilter">The custom event filter to select an <see cref="Event"/> with a specific event payload.</param>
+        /// <param name="timeout">The time period in which the event should be consumed.</param>
+        /// <returns>
+        ///     The deserialized abstract <see cref="Event"/> whose payload matches the specified <paramref name="eventPayloadFilter"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="eventPayloadFilter"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="timeout"/> is a negative time range.</exception>
+        /// <exception cref="TimeoutException">
+        ///     Thrown when no event could be retrieved within the specified <paramref name="timeout"/> time range
+        ///     whose event payload matches the given <paramref name="eventPayloadFilter"/>.
+        /// </exception>
+        public Event GetReceivedEvent<TEventPayload>(Func<TEventPayload, bool> eventPayloadFilter, TimeSpan timeout)
+        {
+            Guard.NotNull(eventPayloadFilter, nameof(eventPayloadFilter), "Requires a function to filter out received CloudEvent events");
+            Guard.NotLessThanOrEqualTo(timeout, TimeSpan.Zero, nameof(timeout), "Requires a timeout span representing a positive time range");
+            
+            Policy<Event> timeoutPolicy = 
+                CreateTimeoutPolicy<Event>(ev => ev != null, timeout);
+
+            PolicyResult<Event> result =
+                timeoutPolicy.ExecuteAndCapture(() =>
+                    TryGetReceivedEvent(ev =>
+                    {
+                        var payload = ev.GetPayload<TEventPayload>();
+                        return payload != null && eventPayloadFilter(payload);
+                    }));
+            
+            if (result.Outcome is OutcomeType.Failure)
+            {
+                throw new TimeoutException(
+                    $"Could not in the time available ({timeout:g}) receive an CloudEvent event from Azure Event Grid on the Service Bus topic that matches the given filter");
             }
 
             return result.Result;
@@ -124,29 +283,61 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
         /// </summary>
         public virtual Task StopAsync()
         {
+            // TODO: job ID to identify event consumer?
             Logger.LogInformation("Host stopped");
 
             return Task.CompletedTask;
         }
 
+        private static Policy<TResult> CreateTimeoutPolicy<TResult>(Func<TResult, bool> resultPredicate, TimeSpan timeout)
+        {
+            // TODO: configurable retry count?
+            Policy<TResult> timeoutPolicy =
+                Policy.Timeout(timeout)
+                      .Wrap(Policy.HandleResult(resultPredicate)
+                                  .WaitAndRetryForever(retryCount => TimeSpan.FromSeconds(1)));
+
+            return timeoutPolicy;
+        }
+
+        private static Event TryGetReceivedEvent(Func<Event, bool> eventFilter)
+        {
+            Event @event = 
+                ReceivedEvents.Values
+                    .Select(value => EventParser.Parse(value.EventPayload))
+                    .SelectMany(batch => batch.Events)
+                    .FirstOrDefault(eventFilter);
+
+            return @event;
+        }
+
         private string TryGetReceivedEvent(string eventId)
         {
-            Logger.LogInformation("Received events are : {receivedEvents}", String.Join(", ", ReceivedEvents.Keys));
-            ReceivedEvents.TryGetValue(eventId, out string rawEvent);
+            Logger.LogTrace("Current received events are: {receivedEvents}", String.Join(", ", ReceivedEvents.Keys));
+            if (ReceivedEvents.TryGetValue(eventId, out EventEntry rawEvent))
+            {
+                Logger.LogInformation("Found received event with ID: {EventId}", eventId);
+                return rawEvent?.EventPayload;
+            }
 
-            return rawEvent;
+            return null;
         }
 
         private static string DetermineEventId(JToken parsedEvent)
         {
-            Guard.NotNull(parsedEvent, nameof(parsedEvent));
-
-            if (((JObject) parsedEvent).TryGetValue("Id", StringComparison.InvariantCultureIgnoreCase, out JToken eventIdNode))
+            if (parsedEvent is null)
+            {
+                throw new InvalidOperationException(
+                    "Could not parse the incoming raw event to a valid JSON structure, make sure that the consumed events in the test are serialized as JSON tokens");
+            }
+            
+            if (parsedEvent is JObject jObject 
+                && jObject.TryGetValue("Id", StringComparison.InvariantCultureIgnoreCase, out JToken eventIdNode))
             {
                 return eventIdNode.ToString();
             }
 
-            return string.Empty;
+            return null;
         }
     }
 }

--- a/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
+++ b/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
@@ -59,12 +59,12 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
             {
                 foreach (JToken parsedEvent in jToken.Children())
                 {
-                    SaveEvent(rawReceivedEvents, logger, parsedEvent);
+                    SaveEvent(parsedEvent, rawReceivedEvents, logger);
                 }
             }
             else if (jToken.Type is JTokenType.Object)
             {
-                SaveEvent(rawReceivedEvents, logger, jToken);
+                SaveEvent(jToken, rawReceivedEvents, logger);
             }
             else
             {
@@ -72,7 +72,7 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
             }
         }
 
-        private static void SaveEvent(string rawReceivedEvents, ILogger logger, JToken parsedEvent)
+        private static void SaveEvent(JToken parsedEvent, string rawReceivedEvents, ILogger logger)
         {
             string eventId = DetermineEventId(parsedEvent);
             if (eventId is null)
@@ -289,6 +289,7 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
                 ReceivedEvents.Values
                     .Select(EventParser.Parse)
                     .SelectMany(batch => batch.Events)
+                    .Where(ev => ev != null)
                     .FirstOrDefault(eventFilter);
 
             return @event;
@@ -296,7 +297,7 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
 
         private string TryGetReceivedEvent(string eventId)
         {
-            Logger.LogTrace("Current received events are: {receivedEvents}", String.Join(", ", ReceivedEvents.Keys));
+            Logger.LogTrace("Current received events are: {ReceivedEvents}", String.Join(", ", ReceivedEvents.Keys));
             if (ReceivedEvents.TryGetValue(eventId, out string rawEvent))
             {
                 Logger.LogInformation("Found received event with ID: {EventId}", eventId);

--- a/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
+++ b/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
@@ -172,7 +172,7 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
             Guard.NotLessThanOrEqualTo(timeout, TimeSpan.Zero, nameof(timeout), "Requires a timeout span representing a positive time range");
 
             Policy<CloudEvent> timeoutPolicy = 
-                CreateTimeoutPolicy<CloudEvent>(ev => ev != null, timeout);
+                CreateTimeoutPolicy<CloudEvent>(ev => ev is null, timeout);
             
             PolicyResult<CloudEvent> result =
                 timeoutPolicy.ExecuteAndCapture(() => 
@@ -206,7 +206,7 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
             Guard.NotLessThanOrEqualTo(timeout, TimeSpan.Zero, nameof(timeout), "Requires a timeout span representing a positive time range");
 
             Policy<EventGridEvent> timeoutPolicy = 
-                CreateTimeoutPolicy<EventGridEvent>(ev => ev != null, timeout);
+                CreateTimeoutPolicy<EventGridEvent>(ev => ev is null, timeout);
             
             PolicyResult<EventGridEvent> result =
                 timeoutPolicy.ExecuteAndCapture(() => 
@@ -242,7 +242,7 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
             Guard.NotLessThanOrEqualTo(timeout, TimeSpan.Zero, nameof(timeout), "Requires a timeout span representing a positive time range");
             
             Policy<Event> timeoutPolicy = 
-                CreateTimeoutPolicy<Event>(ev => ev != null, timeout);
+                CreateTimeoutPolicy<Event>(ev => ev is null, timeout);
 
             PolicyResult<Event> result =
                 timeoutPolicy.ExecuteAndCapture(() =>

--- a/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
+++ b/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
@@ -315,8 +315,7 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
             }
             
             // TODO: configurable event ID retrieval?
-            if (parsedEvent is JObject jObject 
-                && jObject.TryGetValue("Id", StringComparison.InvariantCultureIgnoreCase, out JToken eventIdNode))
+            if (((JObject) parsedEvent).TryGetValue("Id", StringComparison.InvariantCultureIgnoreCase, out JToken eventIdNode))
             {
                 return eventIdNode.ToString();
             }

--- a/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
+++ b/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
@@ -268,7 +268,7 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
         {
             // TODO: job ID to identify event consumer?
             Logger.LogInformation("Host stopped");
-
+            
             return Task.CompletedTask;
         }
 
@@ -283,7 +283,7 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
             return timeoutPolicy;
         }
 
-        private static Event TryGetReceivedEvent(Func<Event, bool> eventFilter)
+        private Event TryGetReceivedEvent(Func<Event, bool> eventFilter)
         {
             Event @event = 
                 ReceivedEvents.Values
@@ -292,6 +292,12 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
                     .Where(ev => ev != null)
                     .FirstOrDefault(eventFilter);
 
+            Logger.LogTrace("Current received events are: {ReceivedEvents}", String.Join(", ", ReceivedEvents.Keys));
+            if (@event != null)
+            {
+                Logger.LogInformation("Found received event with ID: {EventId}", @event.Id);
+            }
+            
             return @event;
         }
 

--- a/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/ServiceBus/ServiceBusEventConsumerHost.cs
+++ b/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/ServiceBus/ServiceBusEventConsumerHost.cs
@@ -104,7 +104,7 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts.ServiceBus
             topicProcessor.ProcessErrorAsync += HandleExceptionAsync;
             await topicProcessor.StartProcessingAsync();
             
-            Logger.LogInformation("Message pump started on '{SubscriptionName}' (topic '{TopicPath}' for endpoint '{ServiceBusEndpoint}')", SubscriptionName, TopicPath, topicProcessor.FullyQualifiedNamespace);
+            Logger.LogInformation("Azure Service Bus event consumer host started on '{SubscriptionName}' (topic '{TopicPath}' for endpoint '{ServiceBusEndpoint}')", SubscriptionName, TopicPath, topicProcessor.FullyQualifiedNamespace);
         }
 
         private async Task HandleNewMessageAsync(ProcessMessageEventArgs eventArgs)

--- a/src/Arcus.EventGrid.Tests.Core/ArcusAssert.cs
+++ b/src/Arcus.EventGrid.Tests.Core/ArcusAssert.cs
@@ -16,6 +16,11 @@ namespace Arcus.EventGrid.Tests.Core
         /// <summary>
         /// Asserts the <see cref="NewCarRegistered"/> event.
         /// </summary>
+        /// <param name="eventId">The expected unique event identifier of the event.</param>
+        /// <param name="eventType">The expected event type of the event.</param>
+        /// <param name="eventSubject">The expected subject of the event.</param>
+        /// <param name="licensePlate">The expected license plate number of the event's payload.</param>
+        /// <param name="receivedEvent">The actual raw event to be asserted.</param>
         public static void ReceivedNewCarRegisteredEvent(string eventId, string eventType, string eventSubject, string licensePlate, string receivedEvent)
         {
             Assert.NotEqual(String.Empty, receivedEvent);
@@ -31,6 +36,16 @@ namespace Arcus.EventGrid.Tests.Core
             Assert.Equal(eventSubject, deserializedEvent.Subject);
             Assert.Equal(eventType, deserializedEvent.EventType);
 
+            ReceivedNewCarRegisteredPayload(licensePlate, deserializedEvent);
+        }
+
+        /// <summary>
+        /// Asserts the <see cref="CarEventData"/> event payload model of an <see cref="NewCarRegistered"/> event.
+        /// </summary>
+        /// <param name="licensePlate">The expected license plate number of the event's payload.</param>
+        /// <param name="deserializedEvent">The actual deserialized event to be asserted.</param>
+        public static void ReceivedNewCarRegisteredPayload(string licensePlate, Event deserializedEvent)
+        {
             Assert.NotNull(deserializedEvent.Data);
             var eventData = deserializedEvent.GetPayload<CarEventData>();
             Assert.NotNull(eventData);

--- a/src/Arcus.EventGrid.Tests.Integration/Publishing/CloudEventPublishing.cs
+++ b/src/Arcus.EventGrid.Tests.Integration/Publishing/CloudEventPublishing.cs
@@ -151,10 +151,10 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
             TracePublishedEvent(eventId, cloudEvent);
 
             // Assert
-            var receivedEvent = 
+            CloudEvent receivedEvent = 
                 _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent(
                     (CloudEvent ev) => ev.Id == eventId, 
-                    TimeSpan.FromSeconds(30));
+                    TimeSpan.FromSeconds(40));
             
             Assert.Equal(eventId, receivedEvent.Id);
             Assert.Equal(cloudEvent.Subject, receivedEvent.Subject);
@@ -191,7 +191,7 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
             TracePublishedEvent(eventId, cloudEvent);
 
             // Assert
-            var receivedEvent = _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent(eventId);
+            string receivedEvent = _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent(eventId);
             ArcusAssert.ReceivedNewCarRegisteredEvent(eventId, cloudEvent.Type, cloudEvent.Subject, licensePlate, receivedEvent);
         }
 

--- a/src/Arcus.EventGrid.Tests.Integration/Publishing/CloudEventPublishing.cs
+++ b/src/Arcus.EventGrid.Tests.Integration/Publishing/CloudEventPublishing.cs
@@ -68,11 +68,11 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
             var eventSubject = $"integration-test-{Guid.NewGuid()}";
             var licensePlate = "1-TOM-337";
             var expected = new CloudEvent(
-                CloudEventsSpecVersion.V1_0,
-                "NewCarRegistered",
-                new Uri("http://test-host"),
-                eventSubject,
-                $"event-id-{Guid.NewGuid()}")
+                specVersion: CloudEventsSpecVersion.V1_0,
+                type: "NewCarRegistered",
+                source: new Uri("http://test-host"),
+                subject: eventSubject,
+                id: $"event-id-{Guid.NewGuid()}")
             {
                 Data = new CarEventData(licensePlate),
                 DataContentType = new ContentType("application/json")
@@ -87,7 +87,7 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
             // Assert
             CloudEvent actual =
                 _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent(
-                    (CloudEvent cloudEvent) => cloudEvent.Subject == expected.Subject,
+                    (CloudEvent cloudEvent) => cloudEvent.Id == expected.Id,
                     TimeSpan.FromSeconds(30));
             Assert.Equal(expected.Id, actual.Id);
             Assert.Equal(expected.Subject, actual.Subject);
@@ -99,7 +99,7 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
         {
             // Arrange
             var eventSubject = $"integration-test-{Guid.NewGuid()}";
-            var licensePlate = "1-TOM-337";
+            var licensePlate = $"1-TOM-{Guid.NewGuid():N}";
             var expected = new CloudEvent(
                 CloudEventsSpecVersion.V1_0,
                 "NewCarRegistered",

--- a/src/Arcus.EventGrid.Tests.Integration/Publishing/CloudEventPublishing.cs
+++ b/src/Arcus.EventGrid.Tests.Integration/Publishing/CloudEventPublishing.cs
@@ -153,7 +153,7 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
             // Assert
             var receivedEvent = 
                 _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent(
-                    (CloudEvent ev) => ev.Id == eventId && ev.Subject == expectedSubject, 
+                    (CloudEvent ev) => ev.Id == eventId, 
                     TimeSpan.FromSeconds(30));
             
             Assert.Equal(eventId, receivedEvent.Id);

--- a/src/Arcus.EventGrid.Tests.Integration/Publishing/CloudEventPublishing.cs
+++ b/src/Arcus.EventGrid.Tests.Integration/Publishing/CloudEventPublishing.cs
@@ -62,40 +62,6 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
         }
 
         [Fact]
-        public async Task PublishSingleCloudEvent_WithEventPayload_ReceivesCloudEventByEventPayload()
-        {
-            // Arrange
-            var eventSubject = $"integration-test-{Guid.NewGuid()}";
-            var licensePlate = $"1-TOM-{Guid.NewGuid():N}";
-            var expected = new CloudEvent(
-                CloudEventsSpecVersion.V1_0,
-                "NewCarRegistered",
-                new Uri("http://test-host"),
-                eventSubject,
-                $"event-id-{Guid.NewGuid()}")
-            {
-                Data = new CarEventData(licensePlate),
-                DataContentType = new ContentType("application/json")
-            };
-
-            IEventGridPublisher publisher = EventPublisherFactory.CreateCloudEventPublisher(_config);
-            
-            // Act
-            await publisher.PublishAsync(expected);
-            TracePublishedEvent(expected.Id, expected);
-            
-            // Assert
-            Event actual =
-                _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent<CarEventData>(
-                    data => data.LicensePlate == licensePlate, 
-                    TimeSpan.FromSeconds(30));
-            
-            Assert.Equal(expected.Id, actual.Id);
-            Assert.Equal(expected.Subject, actual.Subject);
-            ArcusAssert.ReceivedNewCarRegisteredPayload(licensePlate, actual);
-        }
-
-        [Fact]
         public async Task PublishMultipleCloudEvent_WithBuilder_ValidParameters_Succeeds()
         {
             // Arrange
@@ -192,6 +158,7 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
             
             Assert.Equal(eventId, receivedEvent.Id);
             Assert.Equal(cloudEvent.Subject, receivedEvent.Subject);
+            Assert.Equal(cloudEvent.Type, receivedEvent.Type);
             ArcusAssert.ReceivedNewCarRegisteredPayload(licensePlate, receivedEvent);
         }
 

--- a/src/Arcus.EventGrid.Tests.Integration/Publishing/EventGridEventPublishingTests.cs
+++ b/src/Arcus.EventGrid.Tests.Integration/Publishing/EventGridEventPublishingTests.cs
@@ -75,7 +75,7 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
             // Assert
             EventGridEvent actual = 
                 _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent(
-                    (EventGridEvent eventGridEvent) => eventGridEvent.Subject == eventSubject, 
+                    (EventGridEvent eventGridEvent) => eventGridEvent.Id == eventId, 
                     TimeSpan.FromSeconds(30));
 
             Assert.Equal(expected.Id, actual.Id);
@@ -88,7 +88,7 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
         {
             // Arrange
             var eventSubject = $"integration-test-{Guid.NewGuid()}";
-            var licensePlate = "1-TOM-337";
+            var licensePlate = $"1-TOM-{Guid.NewGuid():N}";
             var eventId = Guid.NewGuid().ToString();
             var expected = new NewCarRegistered(eventId, eventSubject, licensePlate); 
 
@@ -101,7 +101,7 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
             // Assert
             Event actual = 
                 _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent<CarEventData>(
-                    data => data.LicensePlate == eventSubject, 
+                    data => data.LicensePlate == licensePlate, 
                     TimeSpan.FromSeconds(30));
 
             Assert.Equal(expected.Id, actual.Id);

--- a/src/Arcus.EventGrid.Tests.Integration/Publishing/EventGridEventPublishingTests.cs
+++ b/src/Arcus.EventGrid.Tests.Integration/Publishing/EventGridEventPublishingTests.cs
@@ -58,32 +58,6 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
         }
 
         [Fact]
-        public async Task PublishSingleEventGridEvent_WithEventSubject_ReceivesEventByEventSubject()
-        {
-            // Arrange
-            var eventSubject = $"integration-test-{Guid.NewGuid()}";
-            var licensePlate = "1-TOM-337";
-            var eventId = Guid.NewGuid().ToString();
-            var expected = new NewCarRegistered(eventId, eventSubject, licensePlate); 
-
-            IEventGridPublisher publisher = EventPublisherFactory.CreateEventGridEventPublisher(_config);
-
-            // Act
-            await publisher.PublishAsync(expected);
-            TracePublishedEvent(eventId, expected);
-
-            // Assert
-            EventGridEvent actual = 
-                _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent(
-                    (EventGridEvent eventGridEvent) => eventGridEvent.Id == eventId, 
-                    TimeSpan.FromSeconds(30));
-
-            Assert.Equal(expected.Id, actual.Id);
-            Assert.Equal(expected.Subject, actual.Subject);
-            ArcusAssert.ReceivedNewCarRegisteredPayload(licensePlate, actual);
-        }
-        
-        [Fact]
         public async Task PublishSingleEventGridEvent_WithEventPayload_ReceivesEventByEventPayload()
         {
             // Arrange
@@ -156,8 +130,15 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
             TracePublishedEvent(eventId, @event);
 
             // Assert
-            var receivedEvent = _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent(eventId);
-            ArcusAssert.ReceivedNewCarRegisteredEvent(eventId, @event.EventType, expectedSubject, licensePlate, receivedEvent);
+            EventGridEvent actual = 
+                _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent(
+                    (EventGridEvent eventGridEvent) => eventGridEvent.Id == eventId, 
+                    TimeSpan.FromSeconds(30));
+
+            Assert.Equal(@event.Id, actual.Id);
+            Assert.Equal(@event.Subject, actual.Subject);
+            Assert.Equal(@event.EventType, actual.EventType);
+            ArcusAssert.ReceivedNewCarRegisteredPayload(licensePlate, actual);
         }
 
         [Fact]

--- a/src/Arcus.EventGrid.Tests.Integration/Publishing/EventGridEventPublishingTests.cs
+++ b/src/Arcus.EventGrid.Tests.Integration/Publishing/EventGridEventPublishingTests.cs
@@ -133,10 +133,9 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
             EventGridEvent actual = 
                 _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent(
                     (EventGridEvent eventGridEvent) => eventGridEvent.Id == eventId, 
-                    TimeSpan.FromSeconds(50));
+                    TimeSpan.FromSeconds(30));
 
             Assert.Equal(@event.Id, actual.Id);
-            Assert.Equal(@event.Subject, actual.Subject);
             Assert.Equal(@event.EventType, actual.EventType);
             ArcusAssert.ReceivedNewCarRegisteredPayload(licensePlate, actual);
         }

--- a/src/Arcus.EventGrid.Tests.Integration/Publishing/EventGridEventPublishingTests.cs
+++ b/src/Arcus.EventGrid.Tests.Integration/Publishing/EventGridEventPublishingTests.cs
@@ -133,7 +133,7 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
             EventGridEvent actual = 
                 _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent(
                     (EventGridEvent eventGridEvent) => eventGridEvent.Id == eventId, 
-                    TimeSpan.FromSeconds(30));
+                    TimeSpan.FromSeconds(50));
 
             Assert.Equal(@event.Id, actual.Id);
             Assert.Equal(@event.Subject, actual.Subject);

--- a/src/Arcus.EventGrid/Contracts/Event.cs
+++ b/src/Arcus.EventGrid/Contracts/Event.cs
@@ -116,7 +116,7 @@ namespace Arcus.EventGrid.Contracts
         /// </summary>
         public static implicit operator CloudEvent(Event @event)
         {
-            return @event.AsCloudEvent();
+            return @event?.AsCloudEvent();
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace Arcus.EventGrid.Contracts
         /// </summary>
         public static implicit operator EventGridEvent(Event @event)
         {
-            return @event.AsEventGridEvent();
+            return @event?.AsEventGridEvent();
         }
 
         /// <summary>
@@ -132,6 +132,11 @@ namespace Arcus.EventGrid.Contracts
         /// </summary>
         public static implicit operator Event(CloudEvent cloudEvent)
         {
+            if (cloudEvent is null)
+            {
+                return null;
+            }
+            
             return new Event(
                 id: cloudEvent.Id,
                 subject: cloudEvent.Subject,
@@ -148,6 +153,11 @@ namespace Arcus.EventGrid.Contracts
         /// </summary>
         public static implicit operator Event(EventGridEvent eventGridEvent)
         {
+            if (eventGridEvent is null)
+            {
+                return null;
+            }
+            
             return new Event(
                 id: eventGridEvent.Id,
                 subject: eventGridEvent.Subject,


### PR DESCRIPTION
Add custom event filters to the `EventConsumerHost` to have more approaches on receiving events.

Closes #178 