### PR TITLE
fix: add version prefix to README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ You can use the version script to create a new documentation version based on th
 1. First, make sure your content in the `./preview` directory is ready to be frozen as a version. A version always should be based from master.
 2. Enter a new version number: 
    
-`npm run docusaurus docs:version 1.1.0`
+`npm run docusaurus docs:version v1.1.0`
 
 ---
 When tagging a new version, the document versioning mechanism will:


### PR DESCRIPTION
Adds version prefix to feature docs' `README.md`.

Relates to https://github.com/arcus-azure/arcus/issues/154