### PR TITLE
fix: streamline issue template with other Arcus repo's

### DIFF
--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,19 +1,16 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
 ---
-**What feature would you like to have?**
-A clear and concise description of what feature you'd like to have and what it tries to achieve.
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
-
-## Proposal
-A clear and concise description of what you propose.
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature


### PR DESCRIPTION
Other repo's were using a different template. Let's use the same one here.