### PR TITLE
fix: general event serialization should take into acount cloud events and event grid events

### DIFF
--- a/src/Arcus.EventGrid.Tests.Unit/Events/SerializationTests.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Events/SerializationTests.cs
@@ -1,7 +1,13 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using Arcus.EventGrid.Contracts;
+using Arcus.EventGrid.Parsers;
 using Arcus.EventGrid.Tests.Core.Events;
+using Arcus.EventGrid.Tests.Unit.Artifacts;
+using CloudNative.CloudEvents;
+using Microsoft.Azure.EventGrid.Models;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Arcus.EventGrid.Tests.Unit.Events
@@ -9,7 +15,7 @@ namespace Arcus.EventGrid.Tests.Unit.Events
     public class SerializationTests
     {
         [Fact]
-        public void Parse_ValidRawEvent_ShouldSucceed()
+        public void Serialize_ValidRawEvent_ShouldSucceed()
         {
             // Arrange
             const string eventId = "2d1781af-3a4c-4d7c-bd0c-e34b19da4e66";
@@ -24,6 +30,45 @@ namespace Arcus.EventGrid.Tests.Unit.Events
 
             // Assert
             Assert.Equal(serializedRawEvent, serializedOriginalEvent);
+        }
+
+        [Fact]
+        public void Serialize_CloudEventAsEvent_Succeeds()
+        {
+            // Arrange
+            string expected = EventSamples.AzureBlobStorageCreatedCloudEvent;
+            EventBatch<Event> batch = EventParser.Parse(expected);
+            Event @event = Assert.Single(batch.Events);
+
+            // Act
+            string actual = JsonConvert.SerializeObject(new[] { @event });
+
+            // Assert
+            Assert.Equal(TrimBlanks(expected), TrimBlanks(actual));
+        }
+
+        [Fact]
+        public void Serialize_EventGridEventAsEvent_Succeeds()
+        {
+            // Arrange
+            string json = EventSamples.IoTDeviceDeleteEvent.Trim('[', ']').Replace("5023869Z", "5023869");
+            var ev = JsonConvert.DeserializeObject<EventGridEvent>(json);
+            string expected = JsonConvert.SerializeObject(ev);
+
+            EventBatch<Event> batch = EventParser.Parse(json);
+            Event @event = Assert.Single(batch.Events);
+
+            // Act
+            string actual = JsonConvert.SerializeObject(@event);
+
+            // Assert
+            Assert.Equal(TrimBlanks(expected), TrimBlanks(actual));
+        }
+
+        private static string TrimBlanks(string value)
+        {
+            return value.Replace(" ", string.Empty)
+                        .Replace(Environment.NewLine, string.Empty);
         }
     }
 }

--- a/src/Arcus.EventGrid.Tests.Unit/Parsing/EventParsingTests.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Parsing/EventParsingTests.cs
@@ -240,11 +240,12 @@ namespace Arcus.EventGrid.Tests.Unit.Parsing
             var eventTime = DateTimeOffset.Parse("2018-03-15T10:25:17.7535274");
 
             // Act
-            var eventGridMessage = EventGridParser.Parse(rawEvent);
+            EventBatch<Event> eventGridMessage = EventGridParser.Parse(rawEvent);
 
             // Assert
             Assert.NotNull(eventGridMessage);
             Assert.NotNull(eventGridMessage.Events);
+            Assert.All(eventGridMessage.Events, ev => Assert.True(ev.IsEventGridEvent));
             EventGridEvent eventGridEvent = Assert.Single(eventGridMessage.Events);
             Assert.Equal(topic, eventGridEvent.Topic);
             Assert.Equal(subject, eventGridEvent.Subject);
@@ -300,6 +301,7 @@ namespace Arcus.EventGrid.Tests.Unit.Parsing
             Assert.NotNull(eventGridMessage);
             Assert.NotNull(eventGridMessage.Events);
             EventGridEvent eventGridEvent = Assert.Single(eventGridMessage.Events);
+            Assert.NotNull(eventGridEvent);
             Assert.Equal(topic, eventGridEvent.Topic);
             Assert.Equal(subject, eventGridEvent.Subject);
             Assert.Equal(eventType, eventGridEvent.EventType);
@@ -355,6 +357,7 @@ namespace Arcus.EventGrid.Tests.Unit.Parsing
             Assert.NotNull(eventGridMessage.Events);
             Event eventGridEvent = Assert.Single(eventGridMessage.Events);
             Assert.NotNull(eventGridEvent);
+            Assert.True(eventGridEvent.IsEventGridEvent);
             Assert.Equal(topic, eventGridEvent.Topic);
             Assert.Equal(subject, eventGridEvent.Subject);
             Assert.Equal(eventType, eventGridEvent.EventType);
@@ -465,6 +468,7 @@ namespace Arcus.EventGrid.Tests.Unit.Parsing
             Assert.NotNull(eventBatch.Events);
             CloudEvent cloudEvent = Assert.Single(eventBatch.Events);
             Assert.NotNull(cloudEvent);
+            Assert.True(cloudEvent.IsCloudEvent);
             Assert.Equal(cloudEventsVersion, cloudEvent.SpecVersion);
             Assert.Equal(eventType, cloudEvent.Type);
             Assert.Equal(source, cloudEvent.Source.OriginalString);
@@ -518,6 +522,7 @@ namespace Arcus.EventGrid.Tests.Unit.Parsing
             Assert.NotNull(eventBatch.Events);
             Event cloudEvent = Assert.Single(eventBatch.Events);
             Assert.NotNull(cloudEvent);
+            Assert.True(cloudEvent.IsCloudEvent);
             Assert.Equal(eventType, cloudEvent.EventType);
             Assert.Equal(eventId, cloudEvent.Id);
             Assert.Equal(eventTime, cloudEvent.EventTime.ToString("O"));

--- a/src/Arcus.EventGrid.Tests.Unit/Parsing/EventParsingTests.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Parsing/EventParsingTests.cs
@@ -466,9 +466,9 @@ namespace Arcus.EventGrid.Tests.Unit.Parsing
             // Assert
             Assert.NotNull(eventBatch);
             Assert.NotNull(eventBatch.Events);
+            Assert.All(eventBatch.Events, ev => Assert.True(ev.IsCloudEvent));
             CloudEvent cloudEvent = Assert.Single(eventBatch.Events);
             Assert.NotNull(cloudEvent);
-            Assert.True(cloudEvent.IsCloudEvent);
             Assert.Equal(cloudEventsVersion, cloudEvent.SpecVersion);
             Assert.Equal(eventType, cloudEvent.Type);
             Assert.Equal(source, cloudEvent.Source.OriginalString);

--- a/src/Arcus.EventGrid/Parsers/EventConverter.cs
+++ b/src/Arcus.EventGrid/Parsers/EventConverter.cs
@@ -35,7 +35,8 @@ namespace Arcus.EventGrid.Parsers
             }
             else if (value.IsEventGridEvent)
             {
-                JObject.FromObject(value.AsEventGridEvent()).WriteTo(writer);
+                var eventGridEvent = value.AsEventGridEvent();
+                JObject.FromObject(eventGridEvent).WriteTo(writer);
             }
         }
 

--- a/src/Arcus.EventGrid/Parsers/EventConverter.cs
+++ b/src/Arcus.EventGrid/Parsers/EventConverter.cs
@@ -1,6 +1,8 @@
 ﻿using System;
-using System.Linq;
+using System.Net.Mime;
+using System.Text;
 using Arcus.EventGrid.Contracts;
+using CloudNative.CloudEvents;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -11,16 +13,30 @@ namespace Arcus.EventGrid.Parsers
     /// </summary>
     public class EventConverter : JsonConverter<Event>
     {
-        /// <summary>Writes the JSON representation of the object.</summary>
+        private static readonly JsonEventFormatter JsonFormatter = new JsonEventFormatter();
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
         /// <param name="writer">The <see cref="T:Newtonsoft.Json.JsonWriter" /> to write to.</param>
         /// <param name="value">The value.</param>
         /// <param name="serializer">The calling serializer.</param>
         public override void WriteJson(JsonWriter writer, Event value, JsonSerializer serializer)
         {
-            JObject.FromObject(value).WriteTo(writer, serializer.Converters.ToArray());
+            if (value.IsCloudEvent)
+            {
+                byte[] contents = JsonFormatter.EncodeStructuredEvent(value, out ContentType contentType);
+                writer.WriteRaw(Encoding.UTF8.GetString(contents));
+            }
+            else if (value.IsEventGridEvent)
+            {
+                JObject.FromObject(value.AsEventGridEvent()).WriteTo(writer);
+            }
         }
 
-        /// <summary>Reads the JSON representation of the object.</summary>
+        /// <summary>
+        /// Reads the JSON representation of the object.
+        /// </summary>
         /// <param name="reader">The <see cref="T:Newtonsoft.Json.JsonReader" /> to read from.</param>
         /// <param name="objectType">Type of the object.</param>
         /// <param name="existingValue">The existing value of object being read. If there is no existing value then <c>null</c> will be used.</param>

--- a/src/Arcus.EventGrid/Parsers/EventConverter.cs
+++ b/src/Arcus.EventGrid/Parsers/EventConverter.cs
@@ -3,6 +3,7 @@ using System.Net.Mime;
 using System.Text;
 using Arcus.EventGrid.Contracts;
 using CloudNative.CloudEvents;
+using GuardNet;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -21,8 +22,12 @@ namespace Arcus.EventGrid.Parsers
         /// <param name="writer">The <see cref="T:Newtonsoft.Json.JsonWriter" /> to write to.</param>
         /// <param name="value">The value.</param>
         /// <param name="serializer">The calling serializer.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="writer"/> or the <paramref name="value"/> is <c>null</c>.</exception>
         public override void WriteJson(JsonWriter writer, Event value, JsonSerializer serializer)
         {
+            Guard.NotNull(writer, nameof(writer), "Requires a JSON writer to write the event");
+            Guard.NotNull(value, nameof(value), "Requires an event instance to write to JSON");
+
             if (value.IsCloudEvent)
             {
                 byte[] contents = JsonFormatter.EncodeStructuredEvent(value, out ContentType contentType);
@@ -43,6 +48,7 @@ namespace Arcus.EventGrid.Parsers
         /// <param name="hasExistingValue">The existing value has a value.</param>
         /// <param name="serializer">The calling serializer.</param>
         /// <returns>The object value.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="reader"/> is <c>null</c>.</exception>
         public override Event ReadJson(
             JsonReader reader,
             Type objectType,
@@ -50,6 +56,8 @@ namespace Arcus.EventGrid.Parsers
             bool hasExistingValue,
             JsonSerializer serializer)
         {
+            Guard.NotNull(reader, nameof(reader), "Requires a JSON reader to read the event");
+
             JObject rawInput = JObject.Load(reader);
             return EventParser.ParseJObject(rawInput);
         }


### PR DESCRIPTION
Make sure that when serializing the `Event` directly, it makes sure that it serializes to the right event type.

Closes #200 