### PR TITLE
chore: upgrade to .net6.0

### DIFF
--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -1,5 +1,5 @@
 variables:
-  DotNet.Sdk.Version: '3.1.201'
-  DotNet.Sdk.VersionBC: '2.2.105'
+  DotNet.Sdk.Version: '6.0.100'
+  DotNet.Sdk.VersionBC: '3.1.201'
   Project: 'Arcus.EventGrid'
   Vm.Image: 'ubuntu-latest'

--- a/src/Arcus.EventGrid.All/Arcus.EventGrid.All.csproj
+++ b/src/Arcus.EventGrid.All/Arcus.EventGrid.All.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.eventgrid/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/arcus-azure/arcus.eventgrid</PackageProjectUrl>

--- a/src/Arcus.EventGrid.Publishing/Arcus.EventGrid.Publishing.csproj
+++ b/src/Arcus.EventGrid.Publishing/Arcus.EventGrid.Publishing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Arcus.EventGrid.snk</AssemblyOriginatorKeyFile>
     <Copyright>Copyright (c) Arcus</Copyright>

--- a/src/Arcus.EventGrid.Security/Arcus.EventGrid.Security.csproj
+++ b/src/Arcus.EventGrid.Security/Arcus.EventGrid.Security.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Arcus.EventGrid.snk</AssemblyOriginatorKeyFile>
     <Copyright>Copyright (c) Arcus</Copyright>
@@ -19,7 +19,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
   </ItemGroup>
 

--- a/src/Arcus.EventGrid.Security/Arcus.EventGrid.Security.csproj
+++ b/src/Arcus.EventGrid.Security/Arcus.EventGrid.Security.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Arcus.EventGrid.snk</AssemblyOriginatorKeyFile>
     <Copyright>Copyright (c) Arcus</Copyright>
@@ -19,7 +19,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
   </ItemGroup>
 

--- a/src/Arcus.EventGrid.Testing/Arcus.EventGrid.Testing.csproj
+++ b/src/Arcus.EventGrid.Testing/Arcus.EventGrid.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.eventgrid/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/Arcus.EventGrid.Tests.Core/Arcus.EventGrid.Tests.Core.csproj
+++ b/src/Arcus.EventGrid.Tests.Core/Arcus.EventGrid.Tests.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.EventGrid.Tests.InMemoryApi/Arcus.EventGrid.Tests.InMemoryApi.csproj
+++ b/src/Arcus.EventGrid.Tests.InMemoryApi/Arcus.EventGrid.Tests.InMemoryApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.EventGrid.Tests.Integration/Arcus.EventGrid.Tests.Integration.csproj
+++ b/src/Arcus.EventGrid.Tests.Integration/Arcus.EventGrid.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.EventGrid.Tests.Unit/Arcus.EventGrid.Tests.Unit.csproj
+++ b/src/Arcus.EventGrid.Tests.Unit/Arcus.EventGrid.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Arcus.EventGrid.Tests.Unit/Artifacts/EventSamples.Designer.cs
+++ b/src/Arcus.EventGrid.Tests.Unit/Artifacts/EventSamples.Designer.cs
@@ -19,7 +19,7 @@ namespace Arcus.EventGrid.Tests.Unit.Artifacts {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class EventSamples {

--- a/src/Arcus.EventGrid.WebApi.Security/Arcus.EventGrid.WebApi.Security.csproj
+++ b/src/Arcus.EventGrid.WebApi.Security/Arcus.EventGrid.WebApi.Security.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.eventgrid/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/arcus-azure/arcus.eventgrid</PackageProjectUrl>

--- a/src/Arcus.EventGrid/Arcus.EventGrid.csproj
+++ b/src/Arcus.EventGrid/Arcus.EventGrid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Arcus.EventGrid.snk</AssemblyOriginatorKeyFile>
     <Authors>Arcus</Authors>


### PR DESCRIPTION
Adds .NET 6 as target framework on the different available projects.

Relates to https://github.com/arcus-azure/arcus/issues/106