### PR TITLE
docs: deprecate old security project

### DIFF
--- a/docs/preview/02-Features/endpoint-validation.md
+++ b/docs/preview/02-Features/endpoint-validation.md
@@ -14,12 +14,11 @@ We provide support for endpoint validation, when implementing your own custom we
 
 The features described here require the following package:
 
+> **⚠ This package used to be called `Arcus.EventGrid.Security`. Please make sure that you migrate towards this package as it's not being actively maintained beyond v3.2.**
+
 ```shell
 PM> Install-Package Arcus.EventGrid.Security.WebApi
 ```
-
-> ⚠ This package used to be called `Arcus.EventGrid.Security`. Please make sure that you migrate towards this package as it's not being actively maintained beyond v3.2.
-
 ## Azure Event Grid authorization
 
 Azure Event Grid authorization allows to secure your webhook with a secret key (taken from the query string or an HTTP header). 

--- a/docs/preview/02-Features/endpoint-validation.md
+++ b/docs/preview/02-Features/endpoint-validation.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Endpoint validation"
 layout: default
 ---
@@ -17,6 +17,8 @@ The features described here require the following package:
 ```shell
 PM> Install-Package Arcus.EventGrid.Security.WebApi
 ```
+
+> ⚠ This package used to be called `Arcus.EventGrid.Security`. Please make sure that you migrate towards this package as it's not being actively maintained beyond v3.2.
 
 ## Azure Event Grid authorization
 

--- a/src/Arcus.EventGrid.Security/EventGridSubscriptionValidator.cs
+++ b/src/Arcus.EventGrid.Security/EventGridSubscriptionValidator.cs
@@ -16,6 +16,7 @@ namespace Arcus.EventGrid.Security
     /// <summary>
     ///     Event grid web hook validation attribute
     /// </summary>
+    [Obsolete("Use the 'Arcus.EventGrid.WebApi.Security' package instead where Azure EventGrid subscription validation happens via an attribute on class and/or operation level")]
     public class EventGridSubscriptionValidator : ActionFilterAttribute
     {
         /// <summary>

--- a/src/Arcus.EventGrid.Security/ResultWithChallenge.cs
+++ b/src/Arcus.EventGrid.Security/ResultWithChallenge.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -7,6 +8,7 @@ using System.Web.Http;
 
 namespace Arcus.EventGrid.Security
 {
+    [Obsolete("Use the 'Arcus.EventGrid.WebApi.Security' package instead where Azure EventGrid authorization and subscription validation is now located")]
     public class ResultWithChallenge : IHttpActionResult
     {
         private const string AuthenticationScheme = "secretkey";


### PR DESCRIPTION
Add remaining obsolete types and add deprecation message on the feature docs page.

Closes #204 