### PR TITLE
chore: update publishing to observability v2 (🚧)

### DIFF
--- a/src/Arcus.EventGrid.Publishing/Arcus.EventGrid.Publishing.csproj
+++ b/src/Arcus.EventGrid.Publishing/Arcus.EventGrid.Publishing.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.4.0,3.0.0)" />
     <PackageReference Include="Flurl.Http" Version="2.3.1" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/src/Arcus.EventGrid.Publishing/Arcus.EventGrid.Publishing.csproj
+++ b/src/Arcus.EventGrid.Publishing/Arcus.EventGrid.Publishing.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[0.2.0,1.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.0,3.0.0)" />
     <PackageReference Include="Flurl.Http" Version="2.3.1" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/src/Arcus.EventGrid.Publishing/EventGridPublisher.cs
+++ b/src/Arcus.EventGrid.Publishing/EventGridPublisher.cs
@@ -306,7 +306,7 @@ namespace Arcus.EventGrid.Publishing
 
         private async Task PublishContentToTopicAsync(HttpContent content, string logEventType)
         {
-            using (DependencyMeasurement measurement = DependencyMeasurement.Start())
+            using (DurationMeasurement measurement = DurationMeasurement.Start())
             {
                 var isSuccessful = false;
                 try

--- a/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
+++ b/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
@@ -22,7 +22,7 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
     public class EventConsumerHost
     {
         // TODO: is 'static' correct here? Multiple event consumers should have different sets of received events, right?
-        private static readonly ConcurrentDictionary<string, string> ReceivedEvents = new ConcurrentDictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> ReceivedEvents = new ConcurrentDictionary<string, string>();
         
         /// <summary>
         ///     Gets the logger associated with this event consumer.

--- a/src/Arcus.EventGrid.Tests.Integration/Publishing/CloudEventPublishing.cs
+++ b/src/Arcus.EventGrid.Tests.Integration/Publishing/CloudEventPublishing.cs
@@ -154,7 +154,7 @@ namespace Arcus.EventGrid.Tests.Integration.Publishing
             CloudEvent receivedEvent = 
                 _endpoint.ServiceBusEventConsumerHost.GetReceivedEvent(
                     (CloudEvent ev) => ev.Id == eventId, 
-                    TimeSpan.FromSeconds(40));
+                    TimeSpan.FromSeconds(50));
             
             Assert.Equal(eventId, receivedEvent.Id);
             Assert.Equal(cloudEvent.Subject, receivedEvent.Subject);


### PR DESCRIPTION
Streamline observability in Event Grid publishing with Arcus Observability v2.

Closes #219