### PR TITLE
chore: remove installation details from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,6 @@ Azure Event Grid development in a breeze.
 
 ![Arcus](https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png)
 
-# Installation
-
-Easy to install it via NuGet:
-
-- **Publishing**
-
-```shell
-PM > Install-Package Arcus.EventGrid.Publishing
-```
-
-- **Models**
-
-```shell
-PM > Install-Package Arcus.EventGrid
-```
-
-For a more thorough overview, we recommend reading our [documentation](#documentation).
-
 # Documentation
 All documentation can be found on [here](https://eventgrid.arcus-azure.net/).
 


### PR DESCRIPTION
It is hard to maintain and keep up to date and it does not provide enough added-value as it is a duplication of the documentation, so removed the installation details from the `README.md` file.