### PR TITLE
chore: support netstandard2.1 eventgrid core

### DIFF
--- a/src/Arcus.EventGrid.Core/Arcus.EventGrid.Core.csproj
+++ b/src/Arcus.EventGrid.Core/Arcus.EventGrid.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <PackageProjectUrl>https://eventgrid.arcus-azure.net/</PackageProjectUrl>
@@ -21,7 +21,7 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="System.Text.Json" Version="6.0.5" />
   </ItemGroup>
 


### PR DESCRIPTION
Add `netstandard2.1` support to the `Arcus.EventGrid.Core` package, as dependent background jobs are also supporting `netstandard2.1`.