### PR TITLE
feat: use new az sdk in testing

### DIFF
--- a/src/Arcus.EventGrid.Testing/Arcus.EventGrid.Testing.csproj
+++ b/src/Arcus.EventGrid.Testing/Arcus.EventGrid.Testing.csproj
@@ -33,6 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.11.0" />
     <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
 

--- a/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
+++ b/src/Arcus.EventGrid.Testing/Infrastructure/Hosts/EventConsumerHost.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Arcus.EventGrid.Contracts;
@@ -11,6 +12,12 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Polly;
 using Polly.Timeout;
+#if NET6_0
+using NewCloudEvent = Azure.Messaging.CloudEvent;
+using NewEventGridEvent = Azure.Messaging.EventGrid.EventGridEvent; 
+#endif
+using OldCloudEvent = CloudNative.CloudEvents.CloudEvent;
+using OldEventGridEvent = Microsoft.Azure.EventGrid.Models.EventGridEvent;
 
 namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
 {
@@ -19,7 +26,8 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
     /// </summary>
     public class EventConsumerHost
     {
-        private readonly ConcurrentDictionary<string, (string originalEvent, Event parsedEvent)> _events = new ConcurrentDictionary<string, (string, Event)>();
+        private readonly ConcurrentDictionary<string, (string originalEvent, Event parsedEvent)> _oldEvents = new ConcurrentDictionary<string, (string, Event)>();
+        private readonly ConcurrentDictionary<string, string> _newEvents = new ConcurrentDictionary<string, string>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EventConsumerHost"/> class.
@@ -72,7 +80,8 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
             foreach (Event receivedEvent in eventBatch.Events)
             {
                 logger.LogTrace("Received event '{EventId}' on event consumer host", receivedEvent.Id);
-                _events.AddOrUpdate(receivedEvent.Id, (rawReceivedEvents, receivedEvent), (id, ev) => (rawReceivedEvents, receivedEvent));
+                _oldEvents.AddOrUpdate(receivedEvent.Id, (rawReceivedEvents, receivedEvent), (id, ev) => (rawReceivedEvents, receivedEvent));
+                _newEvents.AddOrUpdate(receivedEvent.Id, rawReceivedEvents, (id, ev) => rawReceivedEvents);
             }
         }
 
@@ -147,11 +156,12 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
 
             return result.Result;
         }
-        
+
+#if NET6_0
         /// <summary>
         /// Gets the event envelope that includes a requested event (uses timeout).
         /// </summary>
-        /// <param name="cloudEventFilter">The custom event filter to select a specific <see cref="CloudEvent"/> event.</param>
+        /// <param name="cloudEventFilter">The custom event filter to select a specific <see cref="NewCloudEvent "/> event.</param>
         /// <param name="timeout">The time period in which the event should be consumed.</param>
         /// <returns>
         ///     The deserialized <see cref="CloudEvent"/> event that matches the specified <paramref name="cloudEventFilter"/>.
@@ -161,15 +171,58 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
         /// <exception cref="TimeoutException">
         ///     Thrown when no event could be received within the specified <paramref name="timeout"/> time range that matches the given <paramref name="cloudEventFilter"/>.
         /// </exception>
-        public CloudEvent GetReceivedEvent(Func<CloudEvent, bool> cloudEventFilter, TimeSpan timeout)
+        public NewCloudEvent GetReceivedEvent(Func<NewCloudEvent, bool> cloudEventFilter, TimeSpan timeout)
         {
             Guard.NotNull(cloudEventFilter, nameof(cloudEventFilter), "Requires a function to filter out received CloudEvent events");
             Guard.NotLessThanOrEqualTo(timeout, TimeSpan.Zero, nameof(timeout), "Requires a timeout span representing a positive time range");
 
-            Policy<CloudEvent> timeoutPolicy = 
-                CreateTimeoutPolicy<CloudEvent>(ev => ev is null, timeout);
+            Policy<NewCloudEvent> timeoutPolicy =
+                CreateTimeoutPolicy<NewCloudEvent>(ev => ev is null, timeout);
+
+            PolicyResult<NewCloudEvent> result =
+                timeoutPolicy.ExecuteAndCapture(() =>
+                    TryGetReceivedEvent(ev => cloudEventFilter(ev)));
+
+            if (result.Outcome is OutcomeType.Failure)
+            {
+                if (result.FinalException is TimeoutRejectedException)
+                {
+                    throw new TimeoutException(
+                        $"Could not in the time available ({timeout:g}) receive an CloudEvent event from Azure Event Grid on the Service Bus topic that matches the given filter");
+                }
+
+                throw result.FinalException;
+            }
+
+            return result.Result;
+        } 
+#endif
+
+        /// <summary>
+        /// Gets the event envelope that includes a requested event (uses timeout).
+        /// </summary>
+        /// <param name="cloudEventFilter">The custom event filter to select a specific <see cref="OldCloudEvent"/> event.</param>
+        /// <param name="timeout">The time period in which the event should be consumed.</param>
+        /// <returns>
+        ///     The deserialized <see cref="CloudEvent"/> event that matches the specified <paramref name="cloudEventFilter"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cloudEventFilter"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="timeout"/> is a negative time range.</exception>
+        /// <exception cref="TimeoutException">
+        ///     Thrown when no event could be received within the specified <paramref name="timeout"/> time range that matches the given <paramref name="cloudEventFilter"/>.
+        /// </exception>
+#if NET6_0
+        [Obsolete("Use 'CloudEvent' overload from 'Azure.Messaging.EventGrid' package")] 
+#endif
+        public OldCloudEvent GetReceivedEvent(Func<OldCloudEvent, bool> cloudEventFilter, TimeSpan timeout)
+        {
+            Guard.NotNull(cloudEventFilter, nameof(cloudEventFilter), "Requires a function to filter out received CloudEvent events");
+            Guard.NotLessThanOrEqualTo(timeout, TimeSpan.Zero, nameof(timeout), "Requires a timeout span representing a positive time range");
+
+            Policy<OldCloudEvent> timeoutPolicy = 
+                CreateTimeoutPolicy<OldCloudEvent>(ev => ev is null, timeout);
             
-            PolicyResult<CloudEvent> result =
+            PolicyResult<OldCloudEvent> result =
                 timeoutPolicy.ExecuteAndCapture(() => 
                     TryGetReceivedEvent(ev => cloudEventFilter(ev)));
 
@@ -187,10 +240,51 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
             return result.Result;
         }
 
+#if NET6_0
         /// <summary>
         /// Gets the event envelope that includes a requested event (uses timeout).
         /// </summary>
-        /// <param name="eventGridEventFilter">The custom event filter to select a specific <see cref="EventGridEvent"/> event.</param>
+        /// <param name="eventGridEventFilter">The custom event filter to select a specific <see cref="NewEventGridEvent"/> event.</param>
+        /// <param name="timeout">The time period in which the event should be consumed.</param>
+        /// <returns>
+        ///     The deserialized <see cref="NewEventGridEvent"/> event that matches the specified <paramref name="eventGridEventFilter"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="eventGridEventFilter"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="timeout"/> is a negative time range.</exception>
+        /// <exception cref="TimeoutException">
+        ///     Thrown when no event could be received within the specified <paramref name="timeout"/> time range that matches the given <paramref name="eventGridEventFilter"/>.
+        /// </exception>
+        public NewEventGridEvent GetReceivedEvent(Func<NewEventGridEvent, bool> eventGridEventFilter, TimeSpan timeout)
+        {
+            Guard.NotNull(eventGridEventFilter, nameof(eventGridEventFilter), "Requires a function to filter out received CloudEvent events");
+            Guard.NotLessThanOrEqualTo(timeout, TimeSpan.Zero, nameof(timeout), "Requires a timeout span representing a positive time range");
+
+            Policy<NewEventGridEvent> timeoutPolicy =
+                CreateTimeoutPolicy<NewEventGridEvent>(ev => ev is null, timeout);
+
+            PolicyResult<NewEventGridEvent> result =
+                timeoutPolicy.ExecuteAndCapture(() =>
+                    TryGetReceivedEvent(ev => eventGridEventFilter(ev)));
+
+            if (result.Outcome is OutcomeType.Failure)
+            {
+                if (result.FinalException is TimeoutRejectedException)
+                {
+                    throw new TimeoutException(
+                        $"Could not in the time available ({timeout:g}) receive an CloudEvent event from Azure Event Grid on the Service Bus topic that matches the given filter");
+                }
+
+                throw result.FinalException;
+            }
+
+            return result.Result;
+        } 
+#endif
+
+        /// <summary>
+        /// Gets the event envelope that includes a requested event (uses timeout).
+        /// </summary>
+        /// <param name="eventGridEventFilter">The custom event filter to select a specific <see cref="OldEventGridEvent"/> event.</param>
         /// <param name="timeout">The time period in which the event should be consumed.</param>
         /// <returns>
         ///     The deserialized <see cref="EventGridEvent"/> event that matches the specified <paramref name="eventGridEventFilter"/>.
@@ -200,15 +294,18 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
         /// <exception cref="TimeoutException">
         ///     Thrown when no event could be received within the specified <paramref name="timeout"/> time range that matches the given <paramref name="eventGridEventFilter"/>.
         /// </exception>
-        public EventGridEvent GetReceivedEvent(Func<EventGridEvent, bool> eventGridEventFilter, TimeSpan timeout)
+#if NET6_0
+        [Obsolete("Use 'EventGridEvent' overload from 'Azure.Messaging.EventGrid' package")] 
+#endif
+        public OldEventGridEvent GetReceivedEvent(Func<OldEventGridEvent, bool> eventGridEventFilter, TimeSpan timeout)
         {
             Guard.NotNull(eventGridEventFilter, nameof(eventGridEventFilter), "Requires a function to filter out received CloudEvent events");
             Guard.NotLessThanOrEqualTo(timeout, TimeSpan.Zero, nameof(timeout), "Requires a timeout span representing a positive time range");
 
-            Policy<EventGridEvent> timeoutPolicy = 
-                CreateTimeoutPolicy<EventGridEvent>(ev => ev is null, timeout);
+            Policy<OldEventGridEvent> timeoutPolicy = 
+                CreateTimeoutPolicy<OldEventGridEvent>(ev => ev is null, timeout);
             
-            PolicyResult<EventGridEvent> result =
+            PolicyResult<OldEventGridEvent> result =
                 timeoutPolicy.ExecuteAndCapture(() => 
                     TryGetReceivedEvent(ev => eventGridEventFilter(ev)));
 
@@ -241,6 +338,9 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
         ///     Thrown when no event could be retrieved within the specified <paramref name="timeout"/> time range
         ///     whose event payload matches the given <paramref name="eventPayloadFilter"/>.
         /// </exception>
+#if NET6_0
+        [Obsolete("Use either 'CloudEvent' or 'EventGridEvent' overloads")] 
+#endif
         public Event GetReceivedEvent<TEventPayload>(Func<TEventPayload, bool> eventPayloadFilter, TimeSpan timeout)
         {
             Guard.NotNull(eventPayloadFilter, nameof(eventPayloadFilter), "Requires a function to filter out received CloudEvent events");
@@ -293,24 +393,96 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
             return timeoutPolicy;
         }
 
-        private Event TryGetReceivedEvent(Func<Event, bool> eventFilter)
+ #if NET6_0
+        private NewCloudEvent TryGetReceivedEvent(Func<NewCloudEvent, bool> eventFilter)
         {
-            if (_events.IsEmpty)
+            if (_newEvents.IsEmpty)
             {
                 Logger.LogTrace("No received events found");
             }
             else
             {
-                Logger.LogTrace("Current received event batches are: {ReceivedEvents}", String.Join(", ", _events.Keys));
+                Logger.LogTrace("Current received event batches are: {ReceivedEvents}", string.Join(", ", _newEvents.Keys));
 
-                (string eventId, (string originalEvent, Event parsedEvent)) = _events.FirstOrDefault(ev => eventFilter(ev.Value.parsedEvent));
+                foreach (KeyValuePair<string, string> received in _newEvents)
+                {
+                    try
+                    {
+                        var data = BinaryData.FromString(received.Value);
+                        var parsed = NewCloudEvent.Parse(data);
+
+                        if (parsed != null && eventFilter(parsed))
+                        {
+                            Logger.LogInformation("Found received event with ID: {EventId}", parsed.Id);
+                            return parsed;
+                        }
+                    }
+                    catch (Exception exception)
+                    {
+                        Logger.LogTrace(exception, "Could not parse event as CloudEvent: {EventId}", received.Key);
+                    }
+                }
+
+                Logger.LogInformation("None of the received events matches the event filter: {ReceivedEvents}", string.Join(Environment.NewLine, _newEvents.Keys));
+            }
+
+            return null;
+        }
+
+        private NewEventGridEvent TryGetReceivedEvent(Func<NewEventGridEvent, bool> eventFilter)
+        {
+            if (_newEvents.IsEmpty)
+            {
+                Logger.LogTrace("No received events found");
+            }
+            else
+            {
+                Logger.LogTrace("Current received event batches are: {ReceivedEvents}", string.Join(", ", _newEvents.Keys));
+
+                foreach (KeyValuePair<string, string> received in _newEvents)
+                {
+                    try
+                    {
+                        var data = BinaryData.FromString(received.Value);
+                        var parsed = NewEventGridEvent.Parse(data);
+
+                        if (parsed != null && eventFilter(parsed))
+                        {
+                            Logger.LogInformation("Found received event with ID: {EventId}", parsed.Id);
+                            return parsed;
+                        }
+                    }
+                    catch (Exception exception)
+                    {
+                        Logger.LogTrace(exception, "Could not parse event as EventGridEvent: {EventId}", received.Key);
+                    }
+                }
+
+                Logger.LogInformation("None of the received events matches the event filter: {ReceivedEvents}", string.Join(Environment.NewLine, _newEvents.Keys));
+            }
+
+            return null;
+        }
+#endif
+
+        private Event TryGetReceivedEvent(Func<Event, bool> eventFilter)
+        {
+            if (_oldEvents.IsEmpty)
+            {
+                Logger.LogTrace("No received events found");
+            }
+            else
+            {
+                Logger.LogTrace("Current received event batches are: {ReceivedEvents}", String.Join(", ", _oldEvents.Keys));
+
+                (string eventId, (string originalEvent, Event parsedEvent)) = _oldEvents.FirstOrDefault(ev => eventFilter(ev.Value.parsedEvent));
                 if (parsedEvent != null)
                 {
                     Logger.LogInformation("Found received event with ID: {EventId}", eventId);
                 }
                 else
                 {
-                    Logger.LogInformation("None of the received events matches the event filter: {ReceivedEvents}", String.Join(Environment.NewLine, _events.Keys));
+                    Logger.LogInformation("None of the received events matches the event filter: {ReceivedEvents}", String.Join(Environment.NewLine, _oldEvents.Keys));
                 }
 
                 return parsedEvent;
@@ -321,17 +493,17 @@ namespace Arcus.EventGrid.Testing.Infrastructure.Hosts
 
         private string TryGetReceivedEvent(string eventId)
         {
-            if (_events.IsEmpty)
+            if (_newEvents.IsEmpty)
             {
                 Logger.LogTrace("No received events found with event ID: '{EventId}'", eventId);
             }
             else
             {
-                Logger.LogTrace("Current received events are: {ReceivedEvents}", String.Join(", ", _events.Keys));
-                if (_events.TryGetValue(eventId, out (string originalEvent, Event parsedEvent) item))
+                Logger.LogTrace("Current received events are: {ReceivedEvents}", string.Join(", ", _newEvents.Keys));
+                if (_newEvents.TryGetValue(eventId, out string originalEvent))
                 {
                     Logger.LogInformation("Found received event with ID: {EventId}", eventId);
-                    return item.originalEvent;
+                    return originalEvent;
                 }
             }
 

--- a/src/Arcus.EventGrid.Tests.Core/Arcus.EventGrid.Tests.Core.csproj
+++ b/src/Arcus.EventGrid.Tests.Core/Arcus.EventGrid.Tests.Core.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit.assert" Version="2.4.0" />
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.EventGrid.Tests.Core/ArcusAssert.cs
+++ b/src/Arcus.EventGrid.Tests.Core/ArcusAssert.cs
@@ -7,7 +7,6 @@ using Arcus.EventGrid.Tests.Core.Events.Data;
 using Azure.Messaging;
 using Azure.Messaging.EventGrid;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Arcus.EventGrid.Tests.Core
@@ -57,7 +56,6 @@ namespace Arcus.EventGrid.Tests.Core
             Assert.Equal(licensePlate, eventData.LicensePlate);
         }
 
-        
         /// <summary>
         /// Asserts the <see cref="CarEventData"/> event payload model of an <see cref="NewCarRegistered"/> event.
         /// </summary>

--- a/src/Arcus.EventGrid.Tests.Core/ArcusAssert.cs
+++ b/src/Arcus.EventGrid.Tests.Core/ArcusAssert.cs
@@ -1,9 +1,13 @@
 ﻿using System;
+using System.Text;
 using Arcus.EventGrid.Contracts;
 using Arcus.EventGrid.Parsers;
 using Arcus.EventGrid.Tests.Core.Events;
 using Arcus.EventGrid.Tests.Core.Events.Data;
+using Azure.Messaging;
+using Azure.Messaging.EventGrid;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Arcus.EventGrid.Tests.Core
@@ -48,6 +52,34 @@ namespace Arcus.EventGrid.Tests.Core
         {
             Assert.NotNull(deserializedEvent.Data);
             var eventData = deserializedEvent.GetPayload<CarEventData>();
+            Assert.NotNull(eventData);
+            Assert.Equal(JsonConvert.DeserializeObject<CarEventData>(deserializedEvent.Data.ToString()), eventData);
+            Assert.Equal(licensePlate, eventData.LicensePlate);
+        }
+
+        
+        /// <summary>
+        /// Asserts the <see cref="CarEventData"/> event payload model of an <see cref="NewCarRegistered"/> event.
+        /// </summary>
+        /// <param name="licensePlate">The expected license plate number of the event's payload.</param>
+        /// <param name="deserializedEvent">The actual deserialized event to be asserted.</param>
+        public static void ReceivedNewCarRegisteredPayload(string licensePlate, CloudEvent deserializedEvent)
+        {
+            Assert.NotNull(deserializedEvent.Data);
+            var eventData = deserializedEvent.Data.ToObjectFromJson<CarEventData>();
+            Assert.NotNull(eventData);
+            Assert.Equal(licensePlate, eventData.LicensePlate);
+        }
+
+        /// <summary>
+        /// Asserts the <see cref="CarEventData"/> event payload model of an <see cref="NewCarRegistered"/> event.
+        /// </summary>
+        /// <param name="licensePlate">The expected license plate number of the event's payload.</param>
+        /// <param name="deserializedEvent">The actual deserialized event to be asserted.</param>
+        public static void ReceivedNewCarRegisteredPayload(string licensePlate, EventGridEvent deserializedEvent)
+        {
+            Assert.NotNull(deserializedEvent.Data);
+            var eventData = deserializedEvent.Data.ToObjectFromJson<CarEventData>();
             Assert.NotNull(eventData);
             Assert.Equal(JsonConvert.DeserializeObject<CarEventData>(deserializedEvent.Data.ToString()), eventData);
             Assert.Equal(licensePlate, eventData.LicensePlate);


### PR DESCRIPTION
Use new Azure SDK for messaging to use Microsoft's `CloudEvent` and `EventGridEvent` models.