### PR TITLE
docs: correct introduction section

### DIFF
--- a/docs/preview/01-index.md
+++ b/docs/preview/01-index.md
@@ -7,14 +7,12 @@ sidebar_label: Welcome
 
 # Introduction
 
-Arcus EventGrid allows you to work more easily with Azure EventGrid during event publishing and parsing. Instead of worrying about the event type (EventGrid events, CloudEvent events, custom events), Arcus EventGrid allows you to interact with events in a simple manner by parsing the events to a canonical format. Same goes with publishing events where Arcus EventGrid lets you publish in a secure and transient fashion events on EventGrid.
-
-EventGrid is often used in integration tests, so we made sure that retrieving events is easy, transient, and customizable.
+Arcus EventGrid builds on top of Microsoft technology to provide the user with transient publishing and safely registering event publishing to your application with the [Arcus secret store](https://security.arcus-azure.net/features/secret-store). EventGrid is often used in integration tests, so we made sure that retrieving events is easy, transient, and customizable.
 
 # Installation
 
 ```shell
-PM > Install-Package Arcus.EventGrid.All
+PM > Install-Package Arcus.EventGrid.Core
 ```
 
 # License

--- a/docs/versioned_docs/version-v3.3.0/01-index.md
+++ b/docs/versioned_docs/version-v3.3.0/01-index.md
@@ -7,14 +7,12 @@ sidebar_label: Welcome
 
 # Introduction
 
-Arcus EventGrid allows you to work more easily with Azure EventGrid during event publishing and parsing. Instead of worrying about the event type (EventGrid events, CloudEvent events, custom events), Arcus EventGrid allows you to interact with events in a simple manner by parsing the events to a canonical format. Same goes with publishing events where Arcus EventGrid lets you publish in a secure and transient fashion events on EventGrid.
-
-EventGrid is often used in integration tests, so we made sure that retrieving events is easy, transient, and customizable.
+Arcus EventGrid builds on top of Microsoft technology to provide the user with transient publishing and safely registering event publishing to your application with the [Arcus secret store](https://security.arcus-azure.net/features/secret-store). EventGrid is often used in integration tests, so we made sure that retrieving events is easy, transient, and customizable.
 
 # Installation
 
 ```shell
-PM > Install-Package Arcus.EventGrid.All
+PM > Install-Package Arcus.EventGrid.Core
 ```
 
 # License


### PR DESCRIPTION
Correct introduction section in the feature documentation to not include our deprecated event parsing and event contracts.

Closes #282